### PR TITLE
Fix variable expansion in Sora prompt builder

### DIFF
--- a/sora_prompt_builder.sh
+++ b/sora_prompt_builder.sh
@@ -32,19 +32,25 @@ if [[ -z "$POSE" && -z "$DESC" ]]; then
   usage
 fi
 
-python3 - <<'PYEOF'
+export POSE DESC USE_DEAKINS
+python3 - <<PYEOF
+import os
 from promptlib import prompt_orchestrator
 
+pose = os.getenv("POSE", "")
+desc = os.getenv("DESC", "")
+use_deakins = os.getenv("USE_DEAKINS", "0") == "1"
+
 result = prompt_orchestrator(
-    pose_tag=${POSE:+"${POSE}"},
-    subject_description=${DESC:+"${DESC}"},
-    use_deakins=bool(${USE_DEAKINS})
+    pose_tag=pose or None,
+    subject_description=desc or None,
+    use_deakins=use_deakins,
 )
 
-print("─────────────────────────────────────")
+print("\u2500" * 37)
 print("🎬 Final Prompt:")
 print(result["final_prompt"])
-print("─────────────────────────────────────")
+print("\u2500" * 37)
 print(f"🎛️  Base Mode: {result['base_mode']}")
 print(f"🔧 Components Used: {', '.join(result['components_used'])}")
 PYEOF


### PR DESCRIPTION
## Summary
- allow variable expansion in `sora_prompt_builder.sh`
- read values from environment in the embedded Python
- print emojis with UTF-8 characters

## Testing
- `shellcheck sora_prompt_builder.sh`
- `./scripts/integration_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ffc55259c832e88c23f768b735fff