### PR TITLE
Add --help support to sora_prompt_builder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Implement promptlib.py library and sora_prompt_builder.sh CLI for pose-based prompt generation.
 - Update shellcheck workflow to fail on warnings.
 - Added --foreground and --config options to mem-police with a root privilege check.
+- Added --help support to sora_prompt_builder.sh.

--- a/sora_prompt_builder.sh
+++ b/sora_prompt_builder.sh
@@ -12,7 +12,6 @@ usage() {
   printf '%s\n' "  $0 --pose leaning_forward"
   printf '%s\n' "  $0 --desc 'editorial fashion crouch under golden sunlight'"
   printf '%s\n' "  $0 --pose crouching --desc 'moody alley scene' --deakins"
-  exit 1
 }
 
 POSE=""
@@ -24,12 +23,14 @@ while [[ $# -gt 0 ]]; do
     --pose) POSE="$2"; shift 2 ;;
     --desc) DESC="$2"; shift 2 ;;
     --deakins) USE_DEAKINS=1; shift ;;
-    *) usage ;;
+    --help) usage; exit 0 ;;
+    *) usage; exit 1 ;;
   esac
 done
 
 if [[ -z "$POSE" && -z "$DESC" ]]; then
   usage
+  exit 1
 fi
 
 python3 - <<'PYEOF'


### PR DESCRIPTION
## Summary
- update `sora_prompt_builder.sh` argument parsing to handle `--help`
- document the new flag in `docs/CHANGELOG.md`

## Testing
- `shellcheck sora_prompt_builder.sh`
- `scripts/integration_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ffc672b34832eb9144376bac63604