### PR TITLE
Add dry-run flag to sora_prompt_builder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Implement promptlib.py library and sora_prompt_builder.sh CLI for pose-based prompt generation.
 - Update shellcheck workflow to fail on warnings.
 - Added --foreground and --config options to mem-police with a root privilege check.
+- Added --dry-run option to sora_prompt_builder.sh to print the Python command without executing.

--- a/sora_prompt_builder.sh
+++ b/sora_prompt_builder.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 IFS=$'\n\t'
 
 usage() {
-  printf '%s\n' "Usage: $0 --pose <pose_tag> | --desc <description> [--deakins]"
+  printf '%s\n' "Usage: $0 --pose <pose_tag> | --desc <description> [--deakins] [--dry-run]"
+  printf '%s\n' "  --dry-run    Print the Python command instead of executing"
   printf '%s\n' "Examples:"
   printf '%s\n' "  $0 --pose leaning_forward"
   printf '%s\n' "  $0 --desc 'editorial fashion crouch under golden sunlight'"
@@ -18,12 +19,15 @@ usage() {
 POSE=""
 DESC=""
 USE_DEAKINS=0
+DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pose) POSE="$2"; shift 2 ;;
     --desc) DESC="$2"; shift 2 ;;
     --deakins) USE_DEAKINS=1; shift ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --help) usage ;;
     *) usage ;;
   esac
 done
@@ -32,7 +36,7 @@ if [[ -z "$POSE" && -z "$DESC" ]]; then
   usage
 fi
 
-python3 - <<'PYEOF'
+python_script=$(cat <<'PYCODE'
 from promptlib import prompt_orchestrator
 
 result = prompt_orchestrator(
@@ -47,4 +51,13 @@ print(result["final_prompt"])
 print("─────────────────────────────────────")
 print(f"🎛️  Base Mode: {result['base_mode']}")
 print(f"🔧 Components Used: {', '.join(result['components_used'])}")
+PYCODE
+)
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  printf '%s\n%s\n%s\n' "python3 - <<'PYEOF'" "$python_script" "PYEOF"
+else
+  python3 - <<PYEOF
+$python_script
 PYEOF
+fi

--- a/task_outcome.md
+++ b/task_outcome.md
@@ -1,3 +1,4 @@
 This update adds optional foreground execution and a configurable config path to the mem-police daemon. A root privilege check now prevents accidental execution without proper permissions. The changelog and README describe the new options.
 
 Implemented promptlib.py with modular prompt generation functions and a sora_prompt_builder.sh CLI.
+Added --dry-run support to sora_prompt_builder.sh for previewing the Python command before execution.


### PR DESCRIPTION
## Summary
- implement `--dry-run` in `sora_prompt_builder.sh`
- document the new flag

## Testing
- `shellcheck sora_prompt_builder.sh`
- `scripts/integration_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_683ffc6f3810832e9f91529ec350e4a7