### PR TITLE
Fix promptlib executable header and interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Cinematic Prompt Tools
+
+This repository provides utilities for generating cinematic pose prompts for image and video models.
+
+## Components
+
+- **promptlib.py** – Python library with helper functions for constructing and evaluating prompts.
+- **sora_prompt_builder.sh** – Command line interface that uses `promptlib.py` to create prompts.
+
+## Requirements
+
+- Bash and `shellcheck` for linting scripts
+- Python 3.9 or higher
+- Optional: `prompt_toolkit` and `wl-copy` for interactive mode and clipboard support
+
+## Usage
+
+### Generate a Prompt
+
+```
+./sora_prompt_builder.sh --pose crouching
+```
+
+### Interactive Mode
+
+```
+./sora_prompt_builder.sh --interactive
+```
+
+This mode offers autocompletion for pose tags and copies the final prompt to the clipboard when `--copy` is supplied.
+
+### Library Functions
+
+Import the library in your Python code:
+
+```python
+from promptlib import prompt_orchestrator
+result = prompt_orchestrator(pose_tag="crouching")
+print(result["final_prompt"])
+```
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Added --interactive mode to sora_prompt_builder.sh using prompt_toolkit with autocompletion and custom colors.
 - Added --dry-run option to sora_prompt_builder.sh to print the Python command without executing.
 - Added --help support to sora_prompt_builder.sh.
+- Fixed shebang in promptlib.py and corrected interactive exit logic in sora_prompt_builder.sh.

--- a/promptlib.py
+++ b/promptlib.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Prompt generation library for cinematic pose workflows."""
 
 from __future__ import annotations

--- a/sora_prompt_builder.sh
+++ b/sora_prompt_builder.sh
@@ -72,8 +72,8 @@ if [[ $INTERACTIVE -eq 0 && -z "$POSE" && -z "$DESC" ]]; then
 fi
 
 if [[ $INTERACTIVE -eq 1 ]]; then
-	FINAL_OUTPUT=$(
-		python3 - "$USE_DEAKINS" <<'PYEOF'
+        FINAL_OUTPUT=$(
+                python3 - "$USE_DEAKINS" <<'PYEOF'
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.styles import Style
@@ -115,9 +115,9 @@ PYEOF
 		else
 			printf '%s\n' "⚠️  wl-copy not installed. Skipping clipboard copy."
 		fi
-	fi
+        fi
+        exit 0
 fi
-exit 0
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in


### PR DESCRIPTION
## Summary
- fix missing shebang in `promptlib.py`
- correct `sora_prompt_builder.sh` interactive exit logic
- document usage in new README
- note fixes in `CHANGELOG`

## Testing
- `bash scripts/integration_tests.sh`
- `shellcheck sora_prompt_builder.sh`
- `python3 -m py_compile promptlib.py`

------
https://chatgpt.com/codex/tasks/task_e_684118f0c0fc832ea147bf17e39b4f48