### PR TITLE
Fix interactive TTY handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ Thumbs.db
 *.3gp
 *.flv
 *.webp
+.codex-venv/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,3 +11,5 @@
 - Fixed shebang in promptlib.py and corrected interactive exit logic in sora_prompt_builder.sh.
 - Interactive mode in sora_prompt_builder.sh now reads from /dev/tty and reports missing prompt_toolkit.
 - Fixed interactive output handling to prevent 'responds_to_cpr' errors with prompt_toolkit.
+- Improved interactive session to use prompt_toolkit\x27s create_input/create_output for stable TTY handling.
+- Corrected create_input invocation for interactive mode.

--- a/sora_prompt_builder.sh
+++ b/sora_prompt_builder.sh
@@ -65,16 +65,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $INTERACTIVE -eq 1 ]]; then
-        FINAL_OUTPUT=$(
-                python3 - "$USE_DEAKINS" <<'PYEOF'
-import os
-
-from prompt_toolkit import PromptSession
-from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.styles import Style
-from promptlib import prompt_orchestrator, POSE_TAGS
-
+    FINAL_OUTPUT=$(
+        python3 - "$USE_DEAKINS" <<'PYEOF'
 import sys
+
 try:
     from prompt_toolkit import PromptSession
     from prompt_toolkit.completion import WordCompleter
@@ -94,16 +88,6 @@ except OSError as exc:
 
 from promptlib import prompt_orchestrator, POSE_TAGS
 
-try:
-    from prompt_toolkit import PromptSession
-    from prompt_toolkit.completion import WordCompleter
-    from prompt_toolkit.styles import Style
-except ModuleNotFoundError as exc:
-    print("prompt_toolkit is required for interactive mode.", file=sys.stderr)
-    raise SystemExit(1) from exc
-
-from promptlib import prompt_orchestrator, POSE_TAGS
-
 style = Style.from_dict({
     "prompt": "fg:#00f7ff",
     "": "fg:#005b69 bg:#151515",
@@ -111,18 +95,19 @@ style = Style.from_dict({
     "completion-menu.completion.current": "fg:#15FFFF bg:#262626",
 })
 
-try:
-    tty_in = open("/dev/tty")
-except OSError as exc:
-    print("Interactive mode requires a TTY.", file=sys.stderr)
-    raise SystemExit(1) from exc
+with tty_in, tty_out:
+    session = PromptSession(
+        input=create_input(tty_in),
+        output=create_output(tty_out),
+    )
 
-session = PromptSession(input=tty_in, output=sys.stdout)
-pose = session.prompt(
-    "Pose Tag: ", completer=WordCompleter(POSE_TAGS, ignore_case=True), style=style
-)
-desc = session.prompt("Description (optional): ", style=style)
-use_deakins = bool(int(sys.argv[1]))
+    pose = session.prompt(
+        "Pose Tag: ",
+        completer=WordCompleter(POSE_TAGS, ignore_case=True),
+        style=style,
+    )
+    desc = session.prompt("Description (optional): ", style=style)
+    use_deakins = bool(int(sys.argv[1]))
 
 result = prompt_orchestrator(
     pose_tag=pose or None,
@@ -137,17 +122,17 @@ print("────────────────────────�
 print(f"🎛️  Base Mode: {result['base_mode']}")
 print(f"🔧 Components Used: {', '.join(result['components_used'])}")
 PYEOF
-        )
-	printf '%s\n' "$FINAL_OUTPUT"
-	if [[ $COPY_FLAG -eq 1 ]]; then
-		if command -v wl-copy >/dev/null 2>&1; then
-			printf '%s\n' "$FINAL_OUTPUT" | wl-copy
-			printf '%s\n' "📋 Prompt copied to clipboard via wl-copy."
-		else
-			printf '%s\n' "⚠️  wl-copy not installed. Skipping clipboard copy."
-		fi
+    )
+    printf '%s\n' "$FINAL_OUTPUT"
+    if [[ $COPY_FLAG -eq 1 ]]; then
+        if command -v wl-copy >/dev/null 2>&1; then
+            printf '%s\n' "$FINAL_OUTPUT" | wl-copy
+            printf '%s\n' "📋 Prompt copied to clipboard via wl-copy."
+        else
+            printf '%s\n' "⚠️  wl-copy not installed. Skipping clipboard copy."
         fi
-        exit 0
+    fi
+    exit 0
 fi
 
 if [[ -z "$POSE" && -z "$DESC" ]]; then


### PR DESCRIPTION
## Summary
- ensure `.codex-venv` remains ignored
- handle interactive TTY with `prompt_toolkit` safely
- document the improved interactive fix

## Testing
- `shellcheck sora_prompt_builder.sh`
- `scripts/integration_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68413191db54832ebc3cf7a44974e959