### PR TITLE
Update log path to XDG_DATA_HOME

### DIFF
--- a/security/network/ufw.sh
+++ b/security/network/ufw.sh
@@ -51,7 +51,7 @@ declare -i JD_FLAG=0
 declare -i BACKUP_FLAG=0
 
 readonly SCRIPT_NAME="$(basename "$0")"
-readonly LOG_DIR="$HOME/.local/share/logs"
+readonly LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/logs"
 readonly LOG_FILE="$LOG_DIR/ufw.log"
 readonly SYSCTL_UFW_FILE="/etc/sysctl.d/99-ufw-custom.conf"
 readonly BACKUP_DIR="/etc/ufw/backups"


### PR DESCRIPTION
## Summary
- update `LOG_DIR` in `ufw.sh` to check `XDG_DATA_HOME`

## Testing
- `shfmt -d security/network/ufw.sh`
- `shellcheck security/network/ufw.sh`
- `bats -p media/merge.bats` *(fails: `ffmpeg` missing)*
- `bats -p media/ffx_modules/merge.bats` *(fails: `ffmpeg` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842310262a0832ea226180fdd5e935e