### PR TITLE
Fix cleanup dry-run behavior in ufw.sh

### DIFF
--- a/security/network/ufw.sh
+++ b/security/network/ufw.sh
@@ -74,8 +74,8 @@ cleanup() {
 	else
 		log "INFO" "Script exited normally"
 	fi
-	for f in "${TMP_FILES[@]:-}"; do [[ -e "$f" ]] && rm -f "$f" || true; done
-	for d in "${TMP_DIRS[@]:-}"; do [[ -d "$d" ]] && rm -rf "$d" || true; done
+       for f in "${TMP_FILES[@]:-}"; do [[ -e "$f" ]] && run_cmd_dry rm -f "$f" || true; done
+       for d in "${TMP_DIRS[@]:-}"; do [[ -d "$d" ]] && run_cmd_dry rm -rf "$d" || true; done
 	exit "$status"
 }
 trap cleanup EXIT ERR INT TERM HUP


### PR DESCRIPTION
## Summary
- call `run_cmd_dry` when cleaning up files and directories so dry-run is respected

## Testing
- `shellcheck security/network/ufw.sh`
- `shfmt -d security/network/ufw.sh`
- `bats -r 0-tests` *(fails: command not found)*
- manual dry-run check with sample files

------
https://chatgpt.com/codex/tasks/task_e_6842335e2734832eb70656064f34b398