### PR TITLE
Implement plugin loader and Hailuo prompt builder

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## [UNRELEASED]
 - Added 0-tests/codex-merge-clean.sh to remove CODEX merge artifacts.
 - Mandatory use after every CODEX merge or edit before commit/PR.
+- Added genre plugin loader tests for promptlib (test-genre-plugin-loader.bats).

--- a/0-tests/test-genre-plugin-loader.bats
+++ b/0-tests/test-genre-plugin-loader.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+@test "Plugin loader merges plugins with canonical map" {
+	mkdir -p genres
+	cat >genres/fantasy-monster.json <<EOF2
+{
+  "genre": "fantasy-monster",
+  "actions": ["Monster emerges from cave, looks around, and roars."]
+}
+EOF2
+	run env PYTHONPATH="media/prompt_builder" python3 - <<'PY'
+import promptlib
+base = {"fantasy": ["Hero acts heroically."]}
+plugin = promptlib.load_genre_plugins("genres")
+merged = promptlib.merge_action_genres(base, plugin)
+assert "fantasy-monster" in merged and merged["fantasy-monster"]
+PY
+	[ "$status" -eq 0 ]
+}

--- a/media/prompt_builder/tests/test_plugin_loader.py
+++ b/media/prompt_builder/tests/test_plugin_loader.py
@@ -9,9 +9,7 @@ from plugin_loader import (
     load_prompt_plugin_legacy,
 )
 
-PLUGIN = (
-    Path(__file__).resolve().parents[1] / "../prompt_parser/plugins/prompts1.md"
-).resolve()
+PLUGIN = (Path(__file__).resolve().parents[1] / "plugins/prompts1.md").resolve()
 
 
 class PluginLoaderTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expand `promptlib.py` with ACTION_SEQUENCE_GENRE_MAP
- add YAML/JSON genre plugin loader utilities
- implement `build_hailuo_prompt`
- provide bats test for plugin loader
- update plugin loader test paths and CHANGELOG

## Testing
- `pytest -q media/prompt_builder/tests`
- `bats 0-tests/test-genre-plugin-loader.bats`


------
https://chatgpt.com/codex/tasks/task_e_684272f6b5ac832e8324c3d5e11bfd22