### PR TITLE
Fix shellcheck workflow merge markers

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,18 +25,14 @@ jobs:
           reviewdog_flags: '-fail-level=warning'
 
   shfmt:
-    name: Shell Fomatting
+    name: Shell Formatting
     runs-on: ubuntu-latest
     needs: shellcheck
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-<<<<<<< HEAD
-=======
-
       - name: Run shfmt
         uses: reviewdog/action-shfmt@v1
         with:
           shfmt_flags: '-i 4 -ci'
           reviewdog_flags: '-fail-level=warning'
->>>>>>> 809df32 (chore: enforce shellcheck)


### PR DESCRIPTION
## Summary
- fix merge conflict leftovers in `.github/workflows/shellcheck.yml`
- correct job title to **Shell Formatting**

## Testing
- `bats -r 0-tests` *(fails: `codex-merge-clean.sh` not found in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68427a872f74832e9db9090171c90634