### PR TITLE
Fix docstring to avoid escape warnings

### DIFF
--- a/media/prompt_builder/plugin_loader.py
+++ b/media/prompt_builder/plugin_loader.py
@@ -35,7 +35,7 @@ CATEGORY_KEYS: Dict[str, str] = {
 
 
 def load_prompt_plugin_categorized(path: Path) -> Dict[str, List[str]]:
-    """
+    r"""
     Read a Markdown plugin file at `path` and extract quoted blocks under headings.
 
     Returns a dict mapping category → list of prompt-block strings.


### PR DESCRIPTION
## Summary
- mark `load_prompt_plugin_categorized` docstring as raw string
- restore executable bit on `plugin_loader.py`

## Testing
- `pytest -q media/prompt_builder/tests`

------
https://chatgpt.com/codex/tasks/task_e_68427a9d5960832e87dd5cd2e3d98808