### PR TITLE
Ensure genre plugin action deduplication

### DIFF
--- a/0-tests/test-genre-plugin-loader.bats
+++ b/0-tests/test-genre-plugin-loader.bats
@@ -17,3 +17,20 @@ assert "fantasy-monster" in merged and merged["fantasy-monster"]
 PY
 	[ "$status" -eq 0 ]
 }
+
+@test "Loading identical plugins twice deduplicates actions" {
+	mkdir -p genres
+	cat >genres/dup1.json <<EOF
+{
+  "genre": "repeat",
+  "actions": ["roar loudly"]
+}
+EOF
+	cp genres/dup1.json genres/dup2.json
+	run env PYTHONPATH="media/prompt_builder" python3 - <<'PY'
+import promptlib
+plugin = promptlib.load_genre_plugins("genres")
+assert plugin.get("repeat") == ["roar loudly"]
+PY
+	[ "$status" -eq 0 ]
+}

--- a/media/prompt_builder/promptlib.py
+++ b/media/prompt_builder/promptlib.py
@@ -484,6 +484,9 @@ def load_genre_plugins(plugin_dir: str = "genres") -> Dict[str, List[str]]:
             actions = doc.get("actions", [])
             if genre and actions:
                 plugin_map.setdefault(str(genre), []).extend(list(actions))
+    # Deduplicate each genre's action list while preserving order
+    for genre, actions in plugin_map.items():
+        plugin_map[genre] = _dedupe_preserve_order(actions)
     return plugin_map
 
 


### PR DESCRIPTION
## Summary
- deduplicate each genre's action list in `load_genre_plugins`
- verify duplicates are removed by loading identical plugins twice

## Testing
- `pytest -q media/prompt_builder/tests`
- `bats 0-tests/test-genre-plugin-loader.bats`

------
https://chatgpt.com/codex/tasks/task_e_68427aa2bc60832e9beb2bf77b9df24d