### PR TITLE
Fix shellcheck workflow label

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -25,18 +25,15 @@ jobs:
           reviewdog_flags: '-fail-level=warning'
 
   shfmt:
-    name: Shell Fomatting
+    name: Shell Formatting
     runs-on: ubuntu-latest
     needs: shellcheck
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
-<<<<<<< HEAD
-=======
 
       - name: Run shfmt
         uses: reviewdog/action-shfmt@v1
         with:
           shfmt_flags: '-i 4 -ci'
           reviewdog_flags: '-fail-level=warning'
->>>>>>> 809df32 (chore: enforce shellcheck)


### PR DESCRIPTION
## Summary
- fix `Shell Fomatting` typo in shellcheck.yml
- drop leftover merge markers

## Testing
- `bats test-codex-merge-clean.bats` (from 0-tests)
- `bats 0-tests/test-genre-plugin-loader.bats`


------
https://chatgpt.com/codex/tasks/task_e_68427ab23390832e970bd9b7e1c1b42b