### PR TITLE
Fix deakins note placement in prompts.sh

### DIFF
--- a/media/prompt_builder/prompts.sh
+++ b/media/prompt_builder/prompts.sh
@@ -241,15 +241,21 @@ with tty_in, tty_out:
         f"}}"
     ])
 
-    final = "\n".join(lines)
+        final = "\n".join(lines)
     print(final)
 PYEOF
 	)"
+
+	if [[ $USE_DEAKINS -eq 1 ]]; then
+		DEAKINS_NOTE="*Note: Deakins lighting augmentation applied for cinematic realism.*"
+		FINAL_OUTPUT=$(printf '%s\n' "$FINAL_OUTPUT" | sed '/Deakins lighting augmentation applied for cinematic realism\./d')
+	fi
 
 	# Display & auto-copy
 	echo "─────────────────────────────────────"
 	echo "🎬 Final Prompt:"
 	printf '%s\n' "$FINAL_OUTPUT"
+	[[ $USE_DEAKINS -eq 1 ]] && echo "$DEAKINS_NOTE"
 	echo "─────────────────────────────────────"
 	echo "🎛️  Builder Mode: standard"
 	if [[ $USE_DEAKINS -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- filter Deakins note from final prompt block
- echo the note below the generated prompt

## Testing
- `cd 0-tests && bats test-codex-merge-clean.bats`
- `bats 0-tests/test-genre-plugin-loader.bats`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427e8fe970832e907511a4c9dd9fc5