### PR TITLE
Fix deakins note placement

### DIFF
--- a/media/prompt_builder/prompts.sh
+++ b/media/prompt_builder/prompts.sh
@@ -225,6 +225,8 @@ with tty_in, tty_out:
     # If Deakins‐mode, insert the Deakins block here; else insert lighting+shadow
     if use_deakins_flag:
         for dl in build_deakins_block():
+            if "Deakins lighting augmentation" in dl:
+                continue
             lines.append(f"    {dl}")
     else:
         lines.append(f"    {lighting_line}")
@@ -241,7 +243,7 @@ with tty_in, tty_out:
         f"}}"
     ])
 
-        final = "\n".join(lines)
+    final = "\n".join(lines)
     print(final)
 PYEOF
 	)"


### PR DESCRIPTION
## Summary
- remove Deakins lighting line from generated block
- ensure indentation of final assignment is correct

## Testing
- `bash scripts/integration_tests.sh`
- `bats 0-tests` *(fails: `codex-merge-clean.sh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428bb52a70832ebf55c4a75d0bd655