### PR TITLE
Implement canonical param loader

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -2,3 +2,5 @@
 - Added 0-tests/codex-merge-clean.sh to remove CODEX merge artifacts.
 - Mandatory use after every CODEX merge or edit before commit/PR.
 - Added genre plugin loader tests for promptlib (test-genre-plugin-loader.bats).
+
+- Implemented CanonicalParamLoader with hot reload and new tests.

--- a/media/prompt_builder/canonical_loader.py
+++ b/media/prompt_builder/canonical_loader.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Canonical parameter loader with hot reload for promptlib options."""
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List
+
+
+class CanonicalParamLoader:
+    """Load canonical parameters from ``promptlib`` with optional plugin packs.
+
+    Parameters are reloaded automatically if any source file changes. This avoids
+    manual restarts and keeps the parameter set current.
+    """
+
+    def __init__(self, library_dir: str = "media/prompt_builder") -> None:
+        self.library_dir = Path(library_dir).resolve()
+        self.module: ModuleType | None = None
+        self.mtimes: Dict[Path, float] = {}
+        self.params: Dict[str, List[str]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        """Load or reload ``promptlib`` and update parameter mappings."""
+        if self.module is None:
+            import promptlib  # type: ignore
+            self.module = promptlib
+        else:
+            self.module = importlib.reload(self.module)
+
+        self.params = {
+            "pose_tag": list(getattr(self.module, "POSE_TAGS", [])),
+            "camera_move": list(getattr(self.module, "CAMERA_OPTIONS", [])),
+            "lighting": list(getattr(self.module, "LIGHTING_OPTIONS", [])),
+            "lens": list(getattr(self.module, "LENS_OPTIONS", [])),
+            "environment": list(getattr(self.module, "ENVIRONMENT_OPTIONS", [])),
+            "shadow": list(getattr(self.module, "SHADOW_OPTIONS", [])),
+            "detail": list(getattr(self.module, "DETAIL_PROMPTS", [])),
+        }
+        self._record_mtimes()
+
+    def _record_mtimes(self) -> None:
+        """Record modification times for ``library_dir`` contents."""
+        self.mtimes = {}
+        for root, _dirs, files in os.walk(self.library_dir):
+            for name in files:
+                path = Path(root) / name
+                if path.suffix.lower() in {".md", ".txt", ".json", ".yml", ".yaml", ".py"}:
+                    try:
+                        self.mtimes[path] = path.stat().st_mtime
+                    except FileNotFoundError:
+                        continue
+
+    def _check_reload(self) -> None:
+        """Reload parameters if any watched file changed."""
+        for path, old_mtime in list(self.mtimes.items()):
+            try:
+                new_mtime = path.stat().st_mtime
+            except FileNotFoundError:
+                new_mtime = -1
+            if new_mtime != old_mtime:
+                self._load()
+                break
+
+    def get_param_options(self, param_name: str) -> List[str]:
+        """Return the option list for ``param_name``."""
+        self._check_reload()
+        return list(self.params.get(param_name, []))
+
+    def validate_param(self, param_name: str, value: Any) -> bool:
+        """Return ``True`` if ``value`` is canonical for ``param_name``."""
+        options = set(self.get_param_options(param_name))
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            return all(str(v) in options for v in value)
+        return str(value) in options
+
+    def assemble_prompt_block(self, data: Dict[str, Any]) -> str:
+        """Assemble a Hailuo-compliant prompt block from ``data``."""
+        self._check_reload()
+        required = [
+            "subject",
+            "age_tag",
+            "gender_tag",
+            "action_sequence",
+            "camera_moves",
+            "lighting",
+            "lens",
+            "environment",
+            "shadow",
+            "detail",
+        ]
+        for field in required:
+            if field not in data:
+                raise ValueError(f"Missing required parameter: {field}")
+        if not self.validate_param("camera_move", data["camera_moves"]):
+            raise ValueError("Invalid camera moves")
+        if not self.validate_param("lighting", data["lighting"]):
+            raise ValueError("Invalid lighting option")
+        if not self.validate_param("lens", data["lens"]):
+            raise ValueError("Invalid lens option")
+        if not self.validate_param("environment", data["environment"]):
+            raise ValueError("Invalid environment option")
+        if not self.validate_param("shadow", data["shadow"]):
+            raise ValueError("Invalid shadow option")
+        if not self.validate_param("detail", data["detail"]):
+            raise ValueError("Invalid detail option")
+        build = getattr(self.module, "build_hailuo_prompt")
+        return build(
+            subject=data["subject"],
+            age_tag=data["age_tag"],
+            gender_tag=data["gender_tag"],
+            action_sequence=data["action_sequence"],
+            camera_moves=list(data["camera_moves"]),
+            lighting=data["lighting"],
+            lens=data["lens"],
+            environment=data["environment"],
+            detail=data["detail"],
+        )
+
+
+def load_canonical_params(library_dir: str = "media/prompt_builder") -> CanonicalParamLoader:
+    """Convenience function returning a loader instance."""
+    return CanonicalParamLoader(library_dir)
+
+
+__all__ = [
+    "CanonicalParamLoader",
+    "load_canonical_params",
+]

--- a/media/prompt_builder/tests/test_canonical_loader.py
+++ b/media/prompt_builder/tests/test_canonical_loader.py
@@ -1,0 +1,40 @@
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from canonical_loader import CanonicalParamLoader
+
+
+class CanonicalLoaderTest(unittest.TestCase):
+    def setUp(self):
+        self.loader = CanonicalParamLoader("media/prompt_builder")
+
+    def test_validate_param_success(self):
+        lighting = self.loader.get_param_options("lighting")[0]
+        self.assertTrue(self.loader.validate_param("lighting", lighting))
+
+    def test_validate_param_failure(self):
+        self.assertFalse(self.loader.validate_param("lighting", "not_real"))
+
+    def test_assemble_prompt_block(self):
+        data = {
+            "subject": "hero",
+            "age_tag": "adult",
+            "gender_tag": "male",
+            "action_sequence": "runs forward",
+            "camera_moves": [self.loader.get_param_options("camera_move")[0]],
+            "lighting": self.loader.get_param_options("lighting")[0],
+            "lens": self.loader.get_param_options("lens")[0],
+            "environment": self.loader.get_param_options("environment")[0],
+            "shadow": self.loader.get_param_options("shadow")[0],
+            "detail": self.loader.get_param_options("detail")[0],
+        }
+        block = self.loader.assemble_prompt_block(data)
+        self.assertIn("Subject: hero", block)
+        self.assertIn("Action Sequence: runs forward", block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/task_outcome.md
+++ b/task_outcome.md
@@ -1,1 +1,3 @@
 Updated 4ndr0base-beta.sh with dry-run and help options; added tests.
+
+Added CanonicalParamLoader module for Hailuo prompt parameters with tests.


### PR DESCRIPTION
## Summary
- implement `CanonicalParamLoader` with hot reload
- add unit tests for canonical loader
- log work in `CHANGELOG.md` and `task_outcome.md`

## Testing
- `pytest -q`
- `bats 0-tests/test-codex-merge-clean.bats`
- `bats 0-tests/test-genre-plugin-loader.bats`


------
https://chatgpt.com/codex/tasks/task_e_6843ae5d7d04832e88d02d98d8da3acb