### PR TITLE
Integrate extra Hailuo parameters

### DIFF
--- a/media/prompt_builder/canonical_loader.py
+++ b/media/prompt_builder/canonical_loader.py
@@ -39,6 +39,12 @@ class CanonicalParamLoader:
             "environment": list(getattr(self.module, "ENVIRONMENT_OPTIONS", [])),
             "shadow": list(getattr(self.module, "SHADOW_OPTIONS", [])),
             "detail": list(getattr(self.module, "DETAIL_PROMPTS", [])),
+            "age_group": list(getattr(self.module, "AGE_GROUP_OPTIONS", [])),
+            "gender": list(getattr(self.module, "GENDER_OPTIONS", [])),
+            "orientation": list(getattr(self.module, "ORIENTATION_OPTIONS", [])),
+            "expression": list(getattr(self.module, "EXPRESSION_OPTIONS", [])),
+            "shot_framing": list(getattr(self.module, "SHOT_FRAMING_OPTIONS", [])),
+            "action_sequence": list(getattr(self.module, "ACTION_SEQUENCE_OPTIONS", [])),
         }
         self._record_mtimes()
 
@@ -84,10 +90,13 @@ class CanonicalParamLoader:
             "subject",
             "age_tag",
             "gender_tag",
+            "orientation",
+            "expression",
             "action_sequence",
             "camera_moves",
             "lighting",
             "lens",
+            "shot_framing",
             "environment",
             "shadow",
             "detail",
@@ -97,10 +106,16 @@ class CanonicalParamLoader:
                 raise ValueError(f"Missing required parameter: {field}")
         if not self.validate_param("camera_move", data["camera_moves"]):
             raise ValueError("Invalid camera moves")
+        if not self.validate_param("orientation", data["orientation"]):
+            raise ValueError("Invalid orientation option")
+        if not self.validate_param("expression", data["expression"]):
+            raise ValueError("Invalid expression option")
         if not self.validate_param("lighting", data["lighting"]):
             raise ValueError("Invalid lighting option")
         if not self.validate_param("lens", data["lens"]):
             raise ValueError("Invalid lens option")
+        if not self.validate_param("shot_framing", data["shot_framing"]):
+            raise ValueError("Invalid shot framing option")
         if not self.validate_param("environment", data["environment"]):
             raise ValueError("Invalid environment option")
         if not self.validate_param("shadow", data["shadow"]):
@@ -112,10 +127,13 @@ class CanonicalParamLoader:
             subject=data["subject"],
             age_tag=data["age_tag"],
             gender_tag=data["gender_tag"],
+            orientation=data["orientation"],
+            expression=data["expression"],
             action_sequence=data["action_sequence"],
             camera_moves=list(data["camera_moves"]),
             lighting=data["lighting"],
             lens=data["lens"],
+            shot_framing=data["shot_framing"],
             environment=data["environment"],
             detail=data["detail"],
         )

--- a/media/prompt_builder/promptlib.py
+++ b/media/prompt_builder/promptlib.py
@@ -163,6 +163,43 @@ CAMERA_MOVE_TAGS: List[str] = [
 CAMERA_OPTIONS: List[str] = [t.strip("[]") for t in CAMERA_MOVE_TAGS]
 
 # ==============================================================================
+# 3. SUBJECT & SHOT PARAMETERS (age, gender, orientation, expression, framing)
+# ==============================================================================
+AGE_GROUP_OPTIONS: List[str] = ["adult", "teen", "child", "elderly"]
+GENDER_OPTIONS: List[str] = ["male", "female", "neutral"]
+ORIENTATION_OPTIONS: List[str] = ["frontal", "3/4 left", "3/4 right"]
+EXPRESSION_OPTIONS: List[str] = ["neutral", "animated (described in action sequence)"]
+SHOT_FRAMING_OPTIONS: List[str] = [
+    "Close-Up (CU)",
+    "Medium Shot (MS)",
+    "Wide Shot (WS)",
+    "High Angle Shot",
+    "Low Angle Shot",
+    "Bird’s Eye View",
+    "Dutch Angle",
+    "Over-the-Shoulder (OTS)",
+    "Macro / Extreme CU",
+    "Three-Quarter Angle",
+    "Full Shot",
+    "Establishing Shot",
+    "Point of View (POV)",
+    "Cowboy Shot",
+    "Upper Body Shot",
+    "Overhead Shot",
+    "Top-Down View",
+    "Straight-On",
+    "Hero View",
+    "Side View",
+    "Back View",
+    "From Below",
+    "From Behind",
+    "Wide Angle View",
+    "Fisheye View",
+    "Selfie",
+    "Bilaterally Symmetrical",
+]
+
+# ==============================================================================
 # 3. LIGHTING OPTIONS (fully cross-referenced from all files)
 # ==============================================================================
 LIGHTING_OPTIONS: List[str] = [
@@ -388,6 +425,11 @@ ACTION_SEQUENCE_GENRE_MAP: Dict[str, List[str]] = {
     ],
 }
 
+# Flat list of all action sequences for autocompletion
+ACTION_SEQUENCE_OPTIONS: List[str] = []
+for _genre, _seqs in ACTION_SEQUENCE_GENRE_MAP.items():
+    ACTION_SEQUENCE_OPTIONS.extend(_seqs)
+
 # ==============================================================================
 # 9. SUBJECT-REFERENCE RULES (Hailuo compliance, deduped)
 # ==============================================================================
@@ -612,16 +654,31 @@ def build_hailuo_prompt(
     subject: str,
     age_tag: str,
     gender_tag: str,
+    orientation: str,
+    expression: str,
     action_sequence: str,
     camera_moves: List[str],
     lighting: str,
     lens: str,
+    shot_framing: str,
     environment: str,
     detail: str,
 ) -> str:
     """Return a Hailuo/Director Model-compliant prompt block."""
     if not all(
-        [subject.strip(), age_tag.strip(), gender_tag.strip(), action_sequence.strip(), lighting.strip(), lens.strip(), environment.strip(), detail.strip()]
+        [
+            subject.strip(),
+            age_tag.strip(),
+            gender_tag.strip(),
+            orientation.strip(),
+            expression.strip(),
+            action_sequence.strip(),
+            lighting.strip(),
+            lens.strip(),
+            shot_framing.strip(),
+            environment.strip(),
+            detail.strip(),
+        ]
     ) or not camera_moves:
         raise ValueError("All parameters must be non-empty")
     for move in camera_moves:
@@ -631,6 +688,12 @@ def build_hailuo_prompt(
         raise ValueError("Invalid lighting option")
     if lens not in LENS_OPTIONS:
         raise ValueError("Invalid lens option")
+    if orientation not in ORIENTATION_OPTIONS:
+        raise ValueError("Invalid orientation option")
+    if expression not in EXPRESSION_OPTIONS:
+        raise ValueError("Invalid expression option")
+    if shot_framing not in SHOT_FRAMING_OPTIONS:
+        raise ValueError("Invalid shot framing option")
     if environment not in ENVIRONMENT_OPTIONS:
         raise ValueError("Invalid environment option")
     if detail not in DETAIL_PROMPTS:
@@ -639,11 +702,12 @@ def build_hailuo_prompt(
     return (
         f"> {{\n"
         f"    Subject: {subject.strip()}.\n"
-        f"    Age: {age_tag}; Gender: {gender_tag}.\n"
+        f"    Age: {age_tag}; Gender: {gender_tag}; Orientation: {orientation}; Expression: {expression}.\n"
         f"    Action Sequence: {action_sequence}\n"
         f"    Lighting: {lighting}.\n"
         f"    Lens: {lens}.\n"
         f"    Camera: [{camera_str}].\n"
+        f"    Shot/Framing: {shot_framing}.\n"
         f"    Environment: {environment}.\n"
         f"    Detail: {detail}.\n"
         f"    Reference: single unobstructed face, neutral expression unless animated, even facial lighting, minimum 512×512 px, maximum 20 MB file size.\n"
@@ -889,6 +953,12 @@ __all__ = [
     "POSE_DESCRIPTIONS",
     "CAMERA_MOVE_TAGS",
     "CAMERA_OPTIONS",
+    "AGE_GROUP_OPTIONS",
+    "GENDER_OPTIONS",
+    "ORIENTATION_OPTIONS",
+    "EXPRESSION_OPTIONS",
+    "SHOT_FRAMING_OPTIONS",
+    "ACTION_SEQUENCE_OPTIONS",
     "LIGHTING_OPTIONS",
     "LIGHTING_PROFILES",
     "LENS_OPTIONS",
@@ -941,6 +1011,12 @@ LENS_OPTIONS[:] = _dedupe_preserve_order(LENS_OPTIONS)
 ENVIRONMENT_OPTIONS[:] = _dedupe_preserve_order(ENVIRONMENT_OPTIONS)
 SHADOW_OPTIONS[:] = _dedupe_preserve_order(SHADOW_OPTIONS)
 DETAIL_PROMPTS[:] = _dedupe_preserve_order(DETAIL_PROMPTS)
+AGE_GROUP_OPTIONS[:] = _dedupe_preserve_order(AGE_GROUP_OPTIONS)
+GENDER_OPTIONS[:] = _dedupe_preserve_order(GENDER_OPTIONS)
+ORIENTATION_OPTIONS[:] = _dedupe_preserve_order(ORIENTATION_OPTIONS)
+EXPRESSION_OPTIONS[:] = _dedupe_preserve_order(EXPRESSION_OPTIONS)
+SHOT_FRAMING_OPTIONS[:] = _dedupe_preserve_order(SHOT_FRAMING_OPTIONS)
+ACTION_SEQUENCE_OPTIONS[:] = _dedupe_preserve_order(ACTION_SEQUENCE_OPTIONS)
 POLICY_FORBIDDEN_TERMS[:] = _dedupe_preserve_order(POLICY_FORBIDDEN_TERMS)
 
 # Main docstring and user guidance

--- a/media/prompt_builder/prompts.sh
+++ b/media/prompt_builder/prompts.sh
@@ -113,6 +113,12 @@ from promptlib import (
     ENVIRONMENT_OPTIONS,
     SHADOW_OPTIONS,
     DETAIL_PROMPTS,
+    AGE_GROUP_OPTIONS,
+    GENDER_OPTIONS,
+    ORIENTATION_OPTIONS,
+    EXPRESSION_OPTIONS,
+    SHOT_FRAMING_OPTIONS,
+    ACTION_SEQUENCE_OPTIONS,
     build_pose_block,
     build_lighting_block,
     build_shadow_block,
@@ -159,7 +165,35 @@ with tty_in, tty_out:
         output=create_output(tty_out),
     )
 
-    # 1) Pose selection
+    # 1) Age group selection
+    age = session.prompt(
+        "Age Group: ",
+        completer=WordCompleter(AGE_GROUP_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+
+    # 2) Gender selection
+    gender = session.prompt(
+        "Gender: ",
+        completer=WordCompleter(GENDER_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+
+    # 3) Orientation selection
+    orientation = session.prompt(
+        "Orientation: ",
+        completer=WordCompleter(ORIENTATION_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+
+    # 4) Expression selection
+    expression = session.prompt(
+        "Expression: ",
+        completer=WordCompleter(EXPRESSION_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+
+    # 5) Pose selection
     pose = session.prompt(
         "Pose Tag: ",
         completer=WordCompleter(POSE_TAGS, ignore_case=True, match_middle=True),
@@ -167,7 +201,15 @@ with tty_in, tty_out:
     )
     pose_line = build_pose_block(pose).splitlines()[1].strip()
 
-    # 2) Lighting selection
+    # 6) Action sequence selection
+    action_sequence = session.prompt(
+        "Action Sequence: ",
+        completer=WordCompleter(ACTION_SEQUENCE_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+    action_line = f"Action Sequence: {action_sequence}"
+
+    # 7) Lighting selection
     lighting = session.prompt(
         "Lighting (choose one): ",
         completer=WordCompleter(LIGHTING_OPTIONS, ignore_case=True, match_middle=True),
@@ -175,7 +217,7 @@ with tty_in, tty_out:
     )
     lighting_line = build_lighting_block(lighting)
 
-    # 3) Shadow selection
+    # 8) Shadow selection
     shadow = session.prompt(
         "Shadow Quality (choose one): ",
         completer=WordCompleter(SHADOW_OPTIONS, ignore_case=True, match_middle=True),
@@ -183,7 +225,7 @@ with tty_in, tty_out:
     )
     shadow_line = build_shadow_block(shadow)
 
-    # 4) Lens selection
+    # 9) Lens selection
     lens = session.prompt(
         "Lens (choose one): ",
         completer=WordCompleter(LENS_OPTIONS, ignore_case=True, match_middle=True),
@@ -191,7 +233,7 @@ with tty_in, tty_out:
     )
     lens_line = build_lens_block(lens)
 
-    # 5) Camera movement selection
+    # 10) Camera movement selection
     camera_move_input = session.prompt(
         "Camera Movement Tags (comma-separated): ",
         completer=WordCompleter(CAMERA_OPTIONS, ignore_case=True, match_middle=True),
@@ -200,7 +242,15 @@ with tty_in, tty_out:
     camera_tags = [m.strip() for m in camera_move_input.split(",") if m.strip()]
     camera_line = build_camera_block(camera_tags)
 
-    # 6) Environment selection
+    # 11) Shot framing selection
+    shot = session.prompt(
+        "Camera Shot/Framing: ",
+        completer=WordCompleter(SHOT_FRAMING_OPTIONS, ignore_case=True, match_middle=True),
+        style=style,
+    )
+    shot_line = f"Shot/Framing: {shot}."
+
+    # 12) Environment selection
     environment = session.prompt(
         "Environment (choose one): ",
         completer=WordCompleter(ENVIRONMENT_OPTIONS, ignore_case=True, match_middle=True),
@@ -208,7 +258,7 @@ with tty_in, tty_out:
     )
     environment_line = build_environment_block(environment)
 
-    # 7) Detail emphasis selection
+    # 13) Detail emphasis selection
     detail = session.prompt(
         "Micro-detail Focus (choose one): ",
         completer=WordCompleter(DETAIL_PROMPTS, ignore_case=True, match_middle=True),
@@ -220,6 +270,8 @@ with tty_in, tty_out:
     lines = [
         f"> {{",
         f"    {pose_line}",
+        f"    Age: {age}; Gender: {gender}; Orientation: {orientation}; Expression: {expression}.",
+        f"    {action_line}",
     ]
 
     # If Deakins‐mode, insert the Deakins block here; else insert lighting+shadow
@@ -236,6 +288,7 @@ with tty_in, tty_out:
     lines.extend([
         f"    {lens_line}",
         f"    {camera_line}",
+        f"    {shot_line}",
         f"    {environment_line}",
         f"    {detail_line}",
         "",
@@ -261,9 +314,9 @@ PYEOF
 	echo "─────────────────────────────────────"
 	echo "🎛️  Builder Mode: standard"
 	if [[ $USE_DEAKINS -eq 1 ]]; then
-		echo "🔧 Components Used: pose, deakins_lighting, shadow, lens, camera, environment, detail"
+		echo "🔧 Components Used: pose, deakins_lighting, shadow, lens, camera, framing, environment, detail"
 	else
-		echo "🔧 Components Used: pose, lighting, shadow, lens, camera, environment, detail"
+		echo "🔧 Components Used: pose, lighting, shadow, lens, camera, framing, environment, detail"
 	fi
 
 	if command -v wl-copy >/dev/null 2>&1; then

--- a/media/prompt_builder/tests/test_canonical_loader.py
+++ b/media/prompt_builder/tests/test_canonical_loader.py
@@ -23,10 +23,13 @@ class CanonicalLoaderTest(unittest.TestCase):
             "subject": "hero",
             "age_tag": "adult",
             "gender_tag": "male",
+            "orientation": self.loader.get_param_options("orientation")[0],
+            "expression": self.loader.get_param_options("expression")[0],
             "action_sequence": "runs forward",
             "camera_moves": [self.loader.get_param_options("camera_move")[0]],
             "lighting": self.loader.get_param_options("lighting")[0],
             "lens": self.loader.get_param_options("lens")[0],
+            "shot_framing": self.loader.get_param_options("shot_framing")[0],
             "environment": self.loader.get_param_options("environment")[0],
             "shadow": self.loader.get_param_options("shadow")[0],
             "detail": self.loader.get_param_options("detail")[0],
@@ -34,6 +37,7 @@ class CanonicalLoaderTest(unittest.TestCase):
         block = self.loader.assemble_prompt_block(data)
         self.assertIn("Subject: hero", block)
         self.assertIn("Action Sequence: runs forward", block)
+        self.assertIn("Orientation", block)
 
 
 if __name__ == "__main__":

--- a/media/prompt_builder/tests/test_hailuo_prompt.py
+++ b/media/prompt_builder/tests/test_hailuo_prompt.py
@@ -11,6 +11,9 @@ from promptlib import (
     LENS_OPTIONS,
     ENVIRONMENT_OPTIONS,
     DETAIL_PROMPTS,
+    ORIENTATION_OPTIONS,
+    EXPRESSION_OPTIONS,
+    SHOT_FRAMING_OPTIONS,
 )
 
 
@@ -21,10 +24,13 @@ class HailuoPromptTest(unittest.TestCase):
                 subject="hero",
                 age_tag="adult",
                 gender_tag="male",
+                orientation=ORIENTATION_OPTIONS[0],
+                expression=EXPRESSION_OPTIONS[0],
                 action_sequence="runs forward",
                 camera_moves=["fly around"],
                 lighting=LIGHTING_OPTIONS[0],
                 lens=LENS_OPTIONS[0],
+                shot_framing=SHOT_FRAMING_OPTIONS[0],
                 environment=ENVIRONMENT_OPTIONS[0],
                 detail=DETAIL_PROMPTS[0],
             )
@@ -34,15 +40,19 @@ class HailuoPromptTest(unittest.TestCase):
             subject="hero",
             age_tag="adult",
             gender_tag="male",
+            orientation=ORIENTATION_OPTIONS[0],
+            expression=EXPRESSION_OPTIONS[0],
             action_sequence="runs forward",
             camera_moves=[CAMERA_OPTIONS[0], CAMERA_OPTIONS[1]],
             lighting=LIGHTING_OPTIONS[0],
             lens=LENS_OPTIONS[0],
+            shot_framing=SHOT_FRAMING_OPTIONS[0],
             environment=ENVIRONMENT_OPTIONS[0],
             detail=DETAIL_PROMPTS[0],
         )
         self.assertIn("Subject: hero.", result)
         self.assertIn(f"Camera: [{CAMERA_OPTIONS[0]}, {CAMERA_OPTIONS[1]}].", result)
+        self.assertIn("Orientation", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend promptlib with orientation, expression, age group, gender, shot framing and action sequence lists
- expose new options in canonical loader and validation logic
- update prompts.sh interactive builder to prompt for the new parameters
- expand tests for loader and prompt builder

## Testing
- `pytest -q media/prompt_builder/tests`

------
https://chatgpt.com/codex/tasks/task_e_6843ca2c42a8832e8176ed6c8ce5cf03