### PR TITLE
Handle bats-support dependency for media tests

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -8,3 +8,4 @@
   and enhanced dry-run output.
 - Added ffx-vidline.sh combining vidline features with multi-filter support and dry-run option.
 - Improved ffx-vidline.sh ffmpeg status handling to catch failures correctly.
+- Updated media test suites to skip when bats-support is missing and added README instructions.

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -1,3 +1,4 @@
 Updated 4ndr0base-beta.sh with dry-run and help options; added tests.
 
 Added CanonicalParamLoader module for Hailuo prompt parameters with tests.
+Updated media merge tests to gracefully skip when bats-support is unavailable and documented the dependency.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# scr
+
+This repository contains various media and automation scripts.
+
+## Running tests
+
+Bats test suites live under the `media/` and `media/ffx_modules/` directories.
+They rely on the [`bats-support`](https://github.com/bats-core/bats-support) and
+[`bats-assert`](https://github.com/bats-core/bats-assert) helper libraries. Install
+these packages or clone the libraries locally before running `bats`:
+
+```sh
+sudo apt-get install bats bats-support bats-assert
+# or clone locally
+# git clone https://github.com/bats-core/bats-support.git media/bats-support
+# git clone https://github.com/bats-core/bats-assert.git media/bats-assert
+```
+

--- a/media/ffx_modules/merge.bats
+++ b/media/ffx_modules/merge.bats
@@ -1,9 +1,36 @@
 #!/usr/bin/env bats
 
-load '/usr/lib/bats/bats-support/load'
-load '/usr/lib/bats/bats-assert/load'
+# Resolve bats libraries from local or system paths
+support_load=""
+assert_load=""
+for p in "$BATS_TEST_DIRNAME/bats-support/load" "$BATS_TEST_DIRNAME/bats-support/load.bash" \
+         "$BATS_TEST_DIRNAME/../bats-support/load" "$BATS_TEST_DIRNAME/../bats-support/load.bash" \
+         "/usr/lib/bats/bats-support/load" "/usr/lib/bats/bats-support/load.bash"; do
+  if [ -f "$p" ]; then
+    support_load="$p"
+    break
+  fi
+done
+for p in "$BATS_TEST_DIRNAME/bats-assert/load" "$BATS_TEST_DIRNAME/bats-assert/load.bash" \
+         "$BATS_TEST_DIRNAME/../bats-assert/load" "$BATS_TEST_DIRNAME/../bats-assert/load.bash" \
+         "/usr/lib/bats/bats-assert/load" "/usr/lib/bats/bats-assert/load.bash"; do
+  if [ -f "$p" ]; then
+    assert_load="$p"
+    break
+  fi
+done
+
+if [ -n "$support_load" ] && [ -n "$assert_load" ]; then
+  load "$support_load"
+  load "$assert_load"
+else
+  skip_all=true
+fi
 
 setup() {
+  if [ "${skip_all:-false}" = true ]; then
+    skip "bats-support or bats-assert not available"
+  fi
   # Create temp dir for dummy files
   TMPDIR=$(mktemp -d)
   testpath="$TMPDIR/test_merge"
@@ -16,6 +43,9 @@ setup() {
 }
 
 teardown() {
+  if [ "${skip_all:-false}" = true ]; then
+    return
+  fi
   rm -rf "$TMPDIR"
 }
 

--- a/media/merge.bats
+++ b/media/merge.bats
@@ -1,9 +1,36 @@
 #!/usr/bin/env bats
 
-load '/usr/lib/bats/bats-support/load'
-load '/usr/lib/bats/bats-assert/load'
+# Resolve bats libraries from local or system paths
+support_load=""
+assert_load=""
+for p in "$BATS_TEST_DIRNAME/bats-support/load" "$BATS_TEST_DIRNAME/bats-support/load.bash" \
+         "$BATS_TEST_DIRNAME/../bats-support/load" "$BATS_TEST_DIRNAME/../bats-support/load.bash" \
+         "/usr/lib/bats/bats-support/load" "/usr/lib/bats/bats-support/load.bash"; do
+  if [ -f "$p" ]; then
+    support_load="$p"
+    break
+  fi
+done
+for p in "$BATS_TEST_DIRNAME/bats-assert/load" "$BATS_TEST_DIRNAME/bats-assert/load.bash" \
+         "$BATS_TEST_DIRNAME/../bats-assert/load" "$BATS_TEST_DIRNAME/../bats-assert/load.bash" \
+         "/usr/lib/bats/bats-assert/load" "/usr/lib/bats/bats-assert/load.bash"; do
+  if [ -f "$p" ]; then
+    assert_load="$p"
+    break
+  fi
+done
+
+if [ -n "$support_load" ] && [ -n "$assert_load" ]; then
+  load "$support_load"
+  load "$assert_load"
+else
+  skip_all=true
+fi
 
 setup() {
+  if [ "${skip_all:-false}" = true ]; then
+    skip "bats-support or bats-assert not available"
+  fi
   # Create temp dir for dummy files
   TMPDIR=$(mktemp -d)
   testpath="$TMPDIR/test_merge"
@@ -16,6 +43,9 @@ setup() {
 }
 
 teardown() {
+  if [ "${skip_all:-false}" = true ]; then
+    return
+  fi
   rm -rf "$TMPDIR"
 }
 


### PR DESCRIPTION
## Summary
- allow merge.bats suites to run without system bats-support
- document bats-support requirement
- note new skipping logic in changelog
- record outcome of tasks

## Testing
- `shellcheck media/merge.bats media/ffx_modules/merge.bats`
- `bats media/merge.bats` *(fails: `merge` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d96b1c88832e9035d2dc9cdc41ea