### PR TITLE
Fix plugin loader exit code and tests

### DIFF
--- a/0-tests/test-genre-plugin-loader.bats
+++ b/0-tests/test-genre-plugin-loader.bats
@@ -8,7 +8,7 @@
   "actions": ["Monster emerges from cave, looks around, and roars."]
 }
 EOF2
-	run env PYTHONPATH="media/prompt_builder" python3 - <<'PY'
+        run env PYTHONPATH="$BATS_TEST_DIRNAME/../media/prompt_builder" python3 - <<'PY'
 import promptlib
 base = {"fantasy": ["Hero acts heroically."]}
 plugin = promptlib.load_genre_plugins("genres")
@@ -27,10 +27,16 @@ PY
 }
 EOF
 	cp genres/dup1.json genres/dup2.json
-	run env PYTHONPATH="media/prompt_builder" python3 - <<'PY'
+        run env PYTHONPATH="$BATS_TEST_DIRNAME/../media/prompt_builder" python3 - <<'PY'
 import promptlib
 plugin = promptlib.load_genre_plugins("genres")
 assert plugin.get("repeat") == ["roar loudly"]
 PY
-	[ "$status" -eq 0 ]
+        [ "$status" -eq 0 ]
+}
+
+@test "plugin_loader CLI outputs JSON" {
+        run python3 "$BATS_TEST_DIRNAME/../media/prompt_builder/plugin_loader.py" --json "$BATS_TEST_DIRNAME/../media/prompt_builder/plugins/prompts1.md"
+        [ "$status" -eq 0 ]
+        [[ "$output" == \{* ]]
 }

--- a/media/prompt_builder/plugin_loader.py
+++ b/media/prompt_builder/plugin_loader.py
@@ -262,6 +262,8 @@ def main():
         sys.stdout.write(b)
         sys.stdout.write("\0")
 
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/media/prompt_builder/prompts.sh
+++ b/media/prompt_builder/prompts.sh
@@ -346,10 +346,15 @@ for file in "${PLUGIN_FILES[@]}"; do
 		exit 1
 	fi
 
-	# Legacy loading: grab null‐delimited blocks
+	# Legacy loading: grab null-delimited blocks
 	while IFS= read -r -d '' block; do
 		PROMPTS+=("$block")
 	done < <(python3 plugin_loader.py "$file")
+	status=${PIPESTATUS[0]}
+	if [[ $status -ne 0 ]]; then
+		echo "${ERROR} Failed to load plugin: $file" >&2
+		exit "$status"
+	fi
 done
 ## Step 4: If no plugin-loaded prompts (and interactive already handled), exit
 


### PR DESCRIPTION
## Summary
- ensure plugin_loader.py exits with status 0 after printing
- check plugin_loader status in prompts.sh
- make tests location-independent and verify plugin_loader CLI

## Testing
- `bats 0-tests/test-genre-plugin-loader.bats`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d9778dd8832ea9460343b14cde1d