### PR TITLE
Fix shellcheck error in pauseallmpv

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Added ffx-vidline.sh combining vidline features with multi-filter support and dry-run option.
 - Improved ffx-vidline.sh ffmpeg status handling to catch failures correctly.
 - Updated media test suites to skip when bats-support is missing and added README instructions.
+- Updated pauseallmpv with help and dry-run; removed ls iteration.

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -1,4 +1,6 @@
-Updated 4ndr0base-beta.sh with dry-run and help options; added tests.
+Updated 4ndr0base-beta.sh with dry-run and help options
+added tests.
 
 Added CanonicalParamLoader module for Hailuo prompt parameters with tests.
 Updated media merge tests to gracefully skip when bats-support is unavailable and documented the dependency.
+Enhanced pauseallmpv with option parsing and strict mode.

--- a/install/wayland/bin/pauseallmpv
+++ b/install/wayland/bin/pauseallmpv
@@ -1,10 +1,39 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-# You might notice all mpv commands are aliased to have this input-ipc-server
-# thing. That's just for this particular command, which allows us to pause
-# every single one of them with one command! This is bound to super + shift + p
-# (with other things) by default and is used in some other places.
+# pauseallmpv
+# Pauses all running mpv instances by sending a pause command over their
+# IPC sockets found in /tmp/mpvSockets.
 
-for i in $(ls /tmp/mpvSockets/*); do
-	echo '{ "command": ["set_property", "pause", true] }' | socat - "$i";
+set -euo pipefail
+
+usage() {
+	printf 'Usage: %s [--dry-run] [--help]\n' "${0##*/}"
+}
+
+dry_run=0
+while [ $# -gt 0 ]; do
+	case $1 in
+	-h | --help)
+		usage
+		exit 0
+		;;
+	--dry-run)
+		dry_run=1
+		;;
+	*)
+		printf 'Unknown option: %s\n' "$1" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+	shift
+done
+
+for sock in /tmp/mpvSockets/*; do
+	[ -S "$sock" ] || continue
+	if [ "$dry_run" -eq 1 ]; then
+		printf 'Would pause mpv via socket %s\n' "$sock"
+	else
+		printf '{ "command": ["set_property", "pause", true] }' | socat - "$sock"
+	fi
 done


### PR DESCRIPTION
## Summary
- fix shellcheck issue in `pauseallmpv`
- document update in `CHANGELOG` and `task_outcome`

## Testing
- `cd 0-tests && bats test-codex-merge-clean.bats test-genre-plugin-loader.bats`

------
https://chatgpt.com/codex/tasks/task_e_6845394cf4d8832eb18116080d0791e4