### PR TITLE
Refactor makeiso script

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -10,3 +10,5 @@
 - Improved ffx-vidline.sh ffmpeg status handling to catch failures correctly.
 - Updated media test suites to skip when bats-support is missing and added README instructions.
 - Updated pauseallmpv with help and dry-run; removed ls iteration.
+
+- Refactored utilities/iso/makeiso.sh with modular functions, help and dry-run support.


### PR DESCRIPTION
## Summary
- refactor `makeiso.sh` into modular functions
- support `--help` and `--dry-run`
- tighten dependency checks and permissions
- store logs under XDG data directories
- update changelog

## Testing
- `shfmt -w utilities/iso/makeiso.sh`
- `shellcheck utilities/iso/makeiso.sh`
- `cd 0-tests && bats *.bats`

------
https://chatgpt.com/codex/tasks/task_e_6845e78bceb8832e833b4cb5db2b773b