### PR TITLE
Add unified backup script and analysis

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Updated pauseallmpv with help and dry-run; removed ls iteration.
 
 - Refactored utilities/iso/makeiso.sh with modular functions, help and dry-run support.
+- Added bkp-unified.sh combining backup methods with config and ISO support.

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -4,3 +4,4 @@ added tests.
 Added CanonicalParamLoader module for Hailuo prompt parameters with tests.
 Updated media merge tests to gracefully skip when bats-support is unavailable and documented the dependency.
 Enhanced pauseallmpv with option parsing and strict mode.
+Added bkp-unified.sh consolidating backup scripts with dry-run and ISO support.

--- a/maintain/backup/bkp-unified.sh
+++ b/maintain/backup/bkp-unified.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# bkp-unified.sh - Consolidated backup and ISO generation script
+# Dependencies: jq, tar, rsync, mkisofs
+# Requires root privileges
+#
+# This script backs up directories defined in a JSON configuration file,
+# then optionally creates an ISO image from the resulting archive directory.
+# Use --dry-run to preview actions without making changes.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+print_help() {
+	printf 'Usage: %s [--config FILE] [--dry-run] [--help]\n' "${0##*/}"
+	printf '\nOptions:\n'
+	printf '  --config FILE   Path to configuration file\n'
+	printf '  --dry-run       Show actions without executing them\n'
+	printf '  --help          Display this help message\n'
+}
+
+ensure_root() {
+	if [[ $(id -u) -ne 0 ]]; then
+		exec sudo "$0" "$@"
+	fi
+}
+
+require_tools() {
+	local missing=()
+	for tool in "$@"; do
+		command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+	done
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		printf 'Missing required tools: %s\n' "${missing[*]}" >&2
+		exit 1
+	fi
+}
+
+load_config() {
+	local cfg="$1"
+	if [[ ! -f "$cfg" ]]; then
+		printf 'Configuration file not found: %s\n' "$cfg" >&2
+		exit 1
+	fi
+	BACKUP_DIR=$(jq -r '.backup_directory' "$cfg")
+	readarray -t DIRS_TO_BACKUP < <(jq -r '.directories_to_backup[]' "$cfg")
+	ISO_OUTPUT=$(jq -r '.iso_output // empty' "$cfg")
+}
+
+progress_bar() {
+	local total=$1 current=$2 width=50
+	local percent=$((current * 100 / total))
+	local hashes=$((current * width / total))
+	local bar
+	bar=$(printf '%*s' "$hashes" '' | tr ' ' '#')
+	printf '\r[%-*s] %d%%' "$width" "$bar" "$percent"
+}
+
+backup_directories() {
+	mkdir -p "$BACKUP_DIR"
+	local total="${#DIRS_TO_BACKUP[@]}" count=0
+	for dir in "${DIRS_TO_BACKUP[@]}"; do
+		count=$((count + 1))
+		progress_bar "$total" "$count"
+		local base
+		base=$(basename "$dir")
+		local archive
+		archive="$BACKUP_DIR/${base}-$(date +%Y%m%d%H%M%S).tar.gz"
+		if [[ -n "$DRY_RUN" ]]; then
+			printf '\nWould archive %s to %s\n' "$dir" "$archive"
+		else
+			tar -czf "$archive" -C "$(dirname "$dir")" "$base"
+		fi
+	done
+	printf '\n'
+}
+
+create_iso() {
+	[[ -z "$ISO_OUTPUT" ]] && return
+	mkdir -p "$(dirname "$ISO_OUTPUT")"
+	if [[ -n "$DRY_RUN" ]]; then
+		printf 'Would create ISO %s from %s\n' "$ISO_OUTPUT" "$BACKUP_DIR"
+	else
+		mkisofs -o "$ISO_OUTPUT" "$BACKUP_DIR" >/dev/null 2>&1
+	fi
+}
+
+main() {
+	CONFIG_FILE="$HOME/.config/4ndr0tools/backup_config.json"
+	DRY_RUN=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			CONFIG_FILE="$2"
+			shift 2
+			;;
+		--dry-run)
+			DRY_RUN=1
+			shift
+			;;
+		--help)
+			print_help
+			exit 0
+			;;
+		*)
+			print_help
+			exit 1
+			;;
+		esac
+	done
+
+	ensure_root "$@"
+	require_tools jq tar rsync mkisofs
+	load_config "$CONFIG_FILE"
+
+	LOG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/logs"
+	mkdir -p "$LOG_DIR"
+	LOG_FILE="$LOG_DIR/bkp-unified.log"
+
+	if [[ -z "$DRY_RUN" ]]; then
+		: >"$LOG_FILE"
+	fi
+
+	backup_directories | tee -a "$LOG_FILE"
+	create_iso | tee -a "$LOG_FILE"
+
+	printf 'Backup complete. Log at %s\n' "$LOG_FILE"
+}
+
+main "$@"

--- a/maintain/backup/feature_analysis.md
+++ b/maintain/backup/feature_analysis.md
@@ -1,0 +1,29 @@
+# Backup Script Feature Matrix
+
+| Feature | backupconfigs.sh | setup_config_backups.sh | system_iso.sh |
+|---------|-----------------|-------------------------|---------------|
+| Root escalation | yes | no (uses sudo selectively) | no (uses sudo selectively) |
+| Progress bar | yes | no | no |
+| Configuration file | no | yes (JSON) | partial (config file for iso paths) |
+| Help option | no | yes | no |
+| Dry-run mode | no | no | no |
+| Dependency installation | no | jq via pacman | archiso, git, rsync, cdrtools |
+| Cron scheduling | no | yes | no |
+| ISO creation | no | no | yes |
+| Logging | yes | yes | no |
+| Interactive prompts | yes | yes | yes |
+| Color output | minimal | yes | minimal |
+
+## Gaps
+- None of the existing scripts provide a dry-run mode.
+- Only `setup_config_backups.sh` loads a configuration file, leaving the others with hard-coded paths.
+- Dependency management is inconsistent across scripts.
+- ISO creation is only available in `system_iso.sh`.
+
+## Overlaps
+- Both `backupconfigs.sh` and `setup_config_backups.sh` handle logging.
+- All scripts rely on user interaction for input.
+
+The new `bkp-unified.sh` script consolidates configuration-driven backups, root
+escalation, logging under `$XDG_DATA_HOME`, optional ISO creation, and a
+progress bar with an opt-in dry-run mode.


### PR DESCRIPTION
## Summary
- document features and gaps of existing backup scripts
- add `bkp-unified.sh` consolidating backup logic with optional ISO creation
- log the work in `CHANGELOG.md` and `task_outcome.md`

## Testing
- `bats test-codex-merge-clean.bats`
- `bats test-genre-plugin-loader.bats`


------
https://chatgpt.com/codex/tasks/task_e_6845f06ef048832e803322181589ce50