### PR TITLE
Centralize PKG_PATH detection

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -13,3 +13,4 @@
 
 - Refactored utilities/iso/makeiso.sh with modular functions, help and dry-run support.
 - Added bkp-unified.sh combining backup methods with config and ISO support.
+- Consolidated PKG_PATH detection into ensure_pkg_path in common.sh and updated dependent scripts.

--- a/4ndr0tools/4ndr0service/common.sh
+++ b/4ndr0tools/4ndr0service/common.sh
@@ -4,22 +4,27 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Dynamically determine the package base path (PKG_PATH) if not already set
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-	while [[ "$SCRIPT_DIR" != "/" ]]; do
-		if [[ -f "$SCRIPT_DIR/common.sh" ]]; then
-			PKG_PATH="$SCRIPT_DIR"
-			break
-		fi
-		SCRIPT_DIR="$(dirname "$SCRIPT_DIR")"
-	done
-	if [[ -z "${PKG_PATH:-}" ]]; then
-		echo "Error: Could not determine package base path." >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
+ensure_pkg_path() {
+        if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
+                local caller="${BASH_SOURCE[1]:-${BASH_SOURCE[0]:-$0}}"
+                local script_dir
+                script_dir="$(cd -- "$(dirname -- "$caller")" && pwd -P)"
+                while [[ "$script_dir" != "/" ]]; do
+                        if [[ -f "$script_dir/common.sh" ]]; then
+                                PKG_PATH="$script_dir"
+                                break
+                        fi
+                        script_dir="$(dirname "$script_dir")"
+                done
+                if [[ -z "${PKG_PATH:-}" ]]; then
+                        echo "Error: Could not determine package base path." >&2
+                        return 1
+                fi
+        fi
+        export PKG_PATH
+}
+
+ensure_pkg_path
 
 expand_path() {
 	local raw="$1"

--- a/4ndr0tools/4ndr0service/controller.sh
+++ b/4ndr0tools/4ndr0service/controller.sh
@@ -9,21 +9,10 @@ set -euo pipefail
 IFS=$'\n\t'
 
 ### Constants
-# Determine PKG_PATH dynamically for both direct and sourced use
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [ -f "$SCRIPT_DIR/common.sh" ]; then
-	PKG_PATH="$SCRIPT_DIR"
-elif [ -f "$SCRIPT_DIR/../common.sh" ]; then
-	PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-	PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-else
-	echo "Error: Could not determine package path." >&2
-	exit 1
-fi
-export PKG_PATH
+source "$SCRIPT_DIR/common.sh"
+ensure_pkg_path
 
-source "$PKG_PATH/common.sh"
 source "$PKG_PATH/settings_functions.sh"
 source "$PKG_PATH/manage_files.sh"
 source "$PKG_PATH/test/src/verify_environment.sh"

--- a/4ndr0tools/4ndr0service/main.sh
+++ b/4ndr0tools/4ndr0service/main.sh
@@ -9,24 +9,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 ### Constants
-# Determine PKG_PATH dynamically for both direct and sourced use
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	if [ -f "$SCRIPT_DIR/common.sh" ]; then
-		PKG_PATH="$SCRIPT_DIR"
-	elif [ -f "$SCRIPT_DIR/../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-	elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-	else
-		echo "Error: Could not determine package path." >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
+source "$SCRIPT_DIR/common.sh"
+ensure_pkg_path
 
 # Source core modules
-source "$PKG_PATH/common.sh"
 source "$PKG_PATH/controller.sh"
 source "$PKG_PATH/manage_files.sh"
 

--- a/4ndr0tools/4ndr0service/manage_files.sh
+++ b/4ndr0tools/4ndr0service/manage_files.sh
@@ -9,24 +9,11 @@ set -euo pipefail
 IFS=$'\n\t'
 
 ### Constants
-# Determine PKG_PATH dynamically
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	if [ -f "$SCRIPT_DIR/common.sh" ]; then
-		PKG_PATH="$SCRIPT_DIR"
-	elif [ -f "$SCRIPT_DIR/../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-	elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-	else
-		echo "Error: Could not determine package path." >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
+source "$SCRIPT_DIR/common.sh"
+ensure_pkg_path
 
 # Source shared module(s)
-source "$PKG_PATH/common.sh"
 
 # Default backup directory (override with BACKUP_DIR env var if set)
 backup_dir="${BACKUP_DIR:-$HOME/.local/share/4ndr0service/backups}"

--- a/4ndr0tools/4ndr0service/service/optimize_meson.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_meson.sh
@@ -8,19 +8,8 @@ IFS=$'\n\t'
 
 # Determine PKG_PATH and source common utilities
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	if [ -f "$SCRIPT_DIR/../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-	elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-	else
-		echo "Error: Could not determine package path for optimize_meson.sh" >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
-# shellcheck source=../common.sh
-source "$PKG_PATH/common.sh"
+source "$SCRIPT_DIR/../common.sh"
+ensure_pkg_path
 
 install_meson() {
 	if ! command -v meson &>/dev/null; then

--- a/4ndr0tools/4ndr0service/service/optimize_node.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_node.sh
@@ -9,19 +9,8 @@ IFS=$'\n\t'
 
 # Establish PKG_PATH and source common utilities
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	if [ -f "$SCRIPT_DIR/../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-	elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-	else
-		echo "Error: Could not determine package path for optimize_node.sh" >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
-# shellcheck source=../common.sh
-source "$PKG_PATH/common.sh"
+source "$SCRIPT_DIR/../common.sh"
+ensure_pkg_path
 
 # Define XDG-compliant paths for nvm
 export NVM_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/nvm"

--- a/4ndr0tools/4ndr0service/service/optimize_python.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_python.sh
@@ -8,18 +8,8 @@ IFS=$'\n\t'
 
 # Determine PKG_PATH and source common environment
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
-if [[ -z "${PKG_PATH:-}" || ! -f "${PKG_PATH:-}/common.sh" ]]; then
-	if [ -f "$SCRIPT_DIR/../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/.." && pwd -P)"
-	elif [ -f "$SCRIPT_DIR/../../common.sh" ]; then
-		PKG_PATH="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
-	else
-		echo "Error: Could not determine package path for optimize_python.sh" >&2
-		exit 1
-	fi
-fi
-export PKG_PATH
-source "$PKG_PATH/common.sh"
+source "$SCRIPT_DIR/../common.sh"
+ensure_pkg_path
 
 optimize_python_service() {
 	# Configuration


### PR DESCRIPTION
## Summary
- provide `ensure_pkg_path` in `common.sh`
- use `ensure_pkg_path` from `main.sh`, `controller.sh`, `manage_files.sh`
- update service scripts to use the shared function
- document changes in `0-tests/CHANGELOG.md`

## Testing
- `shellcheck 4ndr0tools/4ndr0service/common.sh 4ndr0tools/4ndr0service/controller.sh 4ndr0tools/4ndr0service/main.sh 4ndr0tools/4ndr0service/manage_files.sh 4ndr0tools/4ndr0service/service/optimize_meson.sh 4ndr0tools/4ndr0service/service/optimize_node.sh 4ndr0tools/4ndr0service/service/optimize_python.sh`
- `shfmt -d 4ndr0tools/4ndr0service/common.sh 4ndr0tools/4ndr0service/controller.sh 4ndr0tools/4ndr0service/main.sh 4ndr0tools/4ndr0service/manage_files.sh 4ndr0tools/4ndr0service/service/optimize_meson.sh 4ndr0tools/4ndr0service/service/optimize_node.sh 4ndr0tools/4ndr0service/service/optimize_python.sh`
- `bats $(find . -name '*.bats' | tr '\n' ' ')` *(fails: bats_load_safe: Could not find '/usr/lib/bats/bats-support/load'[.bash])*

------
https://chatgpt.com/codex/tasks/task_e_68466915c7ec832e8c79cfef347c00cf