### PR TITLE
Fix ufw.sh logging and validation

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -14,3 +14,5 @@
 - Refactored utilities/iso/makeiso.sh with modular functions, help and dry-run support.
 - Added bkp-unified.sh combining backup methods with config and ISO support.
 - Consolidated PKG_PATH detection into ensure_pkg_path in common.sh and updated dependent scripts.
+- Refined security/network/ufw.sh with improved logging, rule validation, quoting, and re-enabled ShellCheck.
+- Fixed ufw.sh rule execution by parsing quoted rules correctly and handling ShellCheck warnings.

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -5,3 +5,5 @@ Added CanonicalParamLoader module for Hailuo prompt parameters with tests.
 Updated media merge tests to gracefully skip when bats-support is unavailable and documented the dependency.
 Enhanced pauseallmpv with option parsing and strict mode.
 Added bkp-unified.sh consolidating backup scripts with dry-run and ISO support.
+Enhanced ufw.sh: fixed logging setup, improved rule validation and quoting, switched to printf, enabled ShellCheck.
+Corrected ufw.sh rule handling to parse quoted arguments properly and silenced minor ShellCheck warnings.


### PR DESCRIPTION
## Summary
- re-enable shellcheck for ufw.sh and switch logging to use `printf`
- ensure log directory created before logging
- quote rule variables and enhance validation patterns
- document improvements in CHANGELOG and task outcome
- parse firewall rules correctly when executing

## Testing
- `shellcheck security/network/ufw.sh`
- `shfmt -w security/network/ufw.sh`
- `pre-commit run --files security/network/ufw.sh 0-tests/CHANGELOG.md 0-tests/task_outcome.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854706ff844832ebea4f695edc3d58c