### PR TITLE
Add status flag and swappiness option to ufw script

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -16,3 +16,4 @@
 - Consolidated PKG_PATH detection into ensure_pkg_path in common.sh and updated dependent scripts.
 - Refined security/network/ufw.sh with improved logging, rule validation, quoting, and re-enabled ShellCheck.
 2025-06-19 • security/network/ufw.sh • +16/-4 • Handle missing expressvpn in --vpn flag
+2025-06-20 • security/network/ufw.sh • +91/-22 • Added --status flag, swappiness option, comment support detection, and cleaned tmp logic

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -7,3 +7,4 @@ Enhanced pauseallmpv with option parsing and strict mode.
 Added bkp-unified.sh consolidating backup scripts with dry-run and ISO support.
 Enhanced ufw.sh: fixed logging setup, improved rule validation and quoting, switched to printf, enabled ShellCheck.
 Handled missing expressvpn command for --vpn flag in ufw.sh.
+Implemented status reporting, swappiness parameter, UFW comment detection, and removed unused temp arrays.


### PR DESCRIPTION
## Summary
- implement --status flag for ufw.sh with system info
- add swappiness CLI parameter
- detect ufw comment support and strip when unsupported
- remove unused temp array logic
- document changes in CHANGELOG and task outcomes

## Testing
- `shfmt -d security/network/ufw.sh`
- `shellcheck security/network/ufw.sh`
- `./0-tests/codex-merge-clean.sh security/network/ufw.sh`
- `bats 0-tests/bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e10d9c58832e97c453a48aef0e2e