### PR TITLE
Expand analysis for 4ndr0update

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -20,3 +20,6 @@
 2025-06-23 • maintain/dependencies/deps • +43/-27 • Added dry-run mode, XDG temp usage, and argument fixes
 2025-06-23 • maintain/dependencies/deps-beta • +1/-1 • Fix regex test for essential tools
 2025-06-23 • maintain/dependencies/deps • +93/-3 • Merge beta features, ignore lists, and feature matrix
+2025-06-23 • 4ndr0tools/4ndr0update/ANALYSIS.md • +63/-0 • Add code review analysis of 4ndr0update
+2025-06-23 • 4ndr0tools/4ndr0update/ANALYSIS.md • +49/-63 • Expand review with rewrite approach and improvements
+2025-06-23 • 4ndr0tools/4ndr0update/* • +366/-365 • Apply strict mode, fix bugs, and clean dead code

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -11,3 +11,6 @@ Implemented status reporting, swappiness parameter, UFW comment detection, and r
 Added dry-run option and XDG temp dir to maintain/dependencies/deps; improved argument parsing.
 Tweaked deps-beta requirement check to avoid ShellCheck warning.
 Unified deps script with ignore lists and feature matrix.
+Added analysis for 4ndr0update utility suite.
+Expanded analysis for 4ndr0update with detailed rating and bug fixes.
+Implemented Step 2 items: added strict mode, quoting fixes, removed dead code, fixed typos and duplicate commands.

--- a/4ndr0tools/4ndr0update/ANALYSIS.md
+++ b/4ndr0tools/4ndr0update/ANALYSIS.md
@@ -1,0 +1,49 @@
+# 4ndr0update Code Analysis
+
+`4ndr0update` is a suite of Bash and Python utilities aimed at maintaining and updating an Arch Linux machine.  It provides commands for system upgrades, cleaning, backups and a comprehensive maintenance assistant (`vacuum.py`).  The tools are meant to be executed as root and many scripts rely on interactive prompts.
+
+## How Would I Approach a Rewrite?
+
+A modern rewrite would aim for clearer separation of concerns and more defensive coding.  Shell helpers could be converted to a single executable that dispatches sub‑commands (using `getopts` or a lightweight framework).  Python scripts would live in a package with modules for update logic, backup logic and the TUI.  A configuration file (e.g. under `$XDG_CONFIG_HOME`) would replace the current `settings.sh` sourcing.  Logging should be consistent across all commands.  Unit tests using `bats` (for shell) and `pytest` (for Python) would guard key functions.
+
+## Step 1: Rating
+
+Using the criteria in `CODEX.md`:
+
+* **Modularity – 6/10**  
+  Files are separated, but functions often overlap and some behaviour is duplicated across scripts.  Disabling `shellcheck` reduces clarity.
+* **Scalability – 5/10**  
+  The design targets a single workstation.  Extending to multiple hosts or automated use would require a major refactor because variables are global and the code assumes interactive prompts.
+* **Performance – 7/10**  
+  Most operations wrap fast system tools and Python functions are efficient.  However some commands (e.g. `pacman` invocations) are duplicated and a few loops unnecessarily spawn subshells.
+* **Error Handling – 4/10**  
+  Scripts rarely exit on failure and ignore return codes.  Many commands run without quoting, leading to possible failures with unusual paths.  Python code lacks context managers when opening files or network handles.
+* **User Experience – 7/10**  
+  The mix of CLI, dialog boxes and a TUI is friendly, though repeated confirmations may slow down regular users.
+
+Overall score: **6/10**.  The tools achieve their purpose but leave room for improvement in robustness and maintainability.
+
+## Step 2: Bugs and Enhancement Opportunities
+
+1. **Quoting and Strict Mode**  
+   Enable `set -euo pipefail` and quote variable expansions in every shell script.  For example `source $(pkg_path)/settings.sh` in `main.sh` should be `source "$(pkg_path)/settings.sh"`.
+2. **Remove Dead Code**  
+   `controller.sh` includes large commented sections of unused commands.  Cleaning these out will simplify maintenance.
+3. **Typographical Fixes**  
+   `service/settings.sh` uses `neovimn` instead of `nvim` when opening the editor.
+4. **Duplicate Pacman Calls**  
+   `service/upgrade.sh` runs `retry_command sudo /usr/bin/pacman -Syyu` twice.  The first invocation is redundant and should be removed.
+5. **Improve Python Resource Handling**  
+   `arch_news.py` opens the RSS feed without a context manager.  Use `with urllib.request.urlopen(url) as fh:` to guarantee closure on error.
+6. **Consistent Logging**  
+   Only `vacuum.py` implements structured logging.  Other scripts should write to the same log directory to help debugging.
+7. **Package Distribution**  
+   Packaging the suite as a single Arch package with optional systemd services for backup and update tasks would simplify installation and updates.
+8. **Unit Tests**  
+   The repository lacks automated tests.  Adding `bats` tests for the shell helpers and `pytest` tests for the Python modules would prevent regressions.
+9. **Security Hardening**  
+   Functions like `remove_broken_symlinks` run `rm` directly on user input.  Use safer deletions (`-exec rm -- {}`) and validate targets to avoid accidental deletion outside the intended directories.
+10. **Reduce Global State**  
+   All settings are sourced into the global environment.  Refactoring functions to accept parameters (or reading from a config file) would make the code easier to reason about and extend.
+
+In summary, `4ndr0update` is functional but can be strengthened by applying stricter error checking, consolidating scripts and improving test coverage.  These changes would raise its reliability and make it easier to maintain.

--- a/4ndr0tools/4ndr0update/controller.sh
+++ b/4ndr0tools/4ndr0update/controller.sh
@@ -1,128 +1,70 @@
 #!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 fetch_news() {
-	arch_news
-	printf "\n"
+    arch_news
+    printf "\n"
 }
 
 fixgpg() {
-	4ndr0keyfix
-	printf "\n"
+    4ndr0keyfix
+    printf "\n"
 }
 
 system_upgrade() {
-       printf "➡️ Starting system upgrade..."
-       fetch_news
-       fetch_warnings
-#       configure_reflector
-#       aur_setup
-#       rebuild_aur
-       handle_pacfiles
-       system_update || { fixgpg && system_update; }
-       printf "\n"
+    printf "➡️ Starting system upgrade..."
+    fetch_news
+    fetch_warnings
+    handle_pacfiles
+    system_update || { fixgpg && system_update; }
+    printf "\n"
 
-#	if configure_reflector; then
-#		echo "Reflector configured successfully."
-#	else
-#		echo "Error: Failed to configure reflector."
-#		exit 1
-#	fi
-
-#	if aur_setup; then
-#		echo "AUR setup completed successfully."
-#	else
-#		echo "Error: Failed to set up AUR."
-#		exit 1
-#	fi
-
-#	if rebuild_aur; then
-#		echo "AUR packages rebuilt successfully."
-#	else
-#		echo "Error: Failed to rebuild AUR packages."
-#		exit 1
-#	fi
-
-#	if handle_pacfiles; then
-#		echo "Pacfiles handled successfully."
-#	else
-#		echo "Error: Failed to handle pacfiles."
-#		exit 1
-#	fi
-#
-#	if system_update; then
-#		echo "System update completed successfully."
-#	else
-#		echo "Error: System update failed."
-#		exit 1
-#	fi
-#	printf "✔️ System updated!"
-	printf "\n"
+    printf "\n"
 }
 
 system_clean() {
-	printf "➡️ Cleaning system..."
-        remove_orphaned_packages
-        clean_package_cache
-        clean_broken_symlinks
-        clean_old_config
-#        printf "✔️ System cleaning complete!"
-        printf "\n"
-#	if remove_orphaned_packages; then
-#		echo "Orphaned packages removed."
-#	else
-#		echo "Error: Failed to remove orphaned packages."
-#		exit 1
-#	fi
-
-#	if clean_package_cache; then
-#		echo "Package cache cleaned."
-#	else
-#		echo "Error: Failed to clean package cache."
-#		exit 1
-#	fi
-#
-#	if clean_broken_symlinks; then
-#		echo "Broken symlinks cleaned."
-#	else
-#		echo "Error: Failed to clean broken symlinks."
-#		exit 1
-#	fi
+    printf "➡️ Cleaning system..."
+    remove_orphaned_packages
+    clean_package_cache
+    clean_broken_symlinks
+    clean_old_config
+    printf "\n"
 }
 
 system_errors() {
-	printf "➡️ Scanning system errors\n"
-	failed_services
-	journal_errors
-	printf "\n"
+    printf "➡️ Scanning system errors\n"
+    failed_services
+    journal_errors
+    printf "\n"
 }
 
 backup_system() {
-	printf "➡️ Starting system backup\n"
-	if execute_backup; then
-		printf "✔️ System backup completed successfully.\n"
-	else
-		printf "❌ System backup failed.\n"
-		exit 1
-	fi
-	printf "\n"
+    printf "➡️ Starting system backup\n"
+    if execute_backup; then
+        printf "✔️ System backup completed successfully.\n"
+    else
+        printf "❌ System backup failed.\n"
+        exit 1
+    fi
+    printf "\n"
 }
 
 restore_system() {
-	printf "➡️ Starting system restore\n"
-	if execute_restore; then
-		printf "✔️ System restored successfully\n"
-	else
-		printf "❌ System restore failed.\n"
-		exit 1
-	fi
-	printf "\n"
+    printf "➡️ Starting system restore\n"
+    if execute_restore; then
+        printf "✔️ System restored successfully\n"
+    else
+        printf "❌ System restore failed.\n"
+        exit 1
+    fi
+    printf "\n"
 }
 
 update_settings() {
-	printf "➡️ Updating settings\n"
-	modify_settings
-	source_settings
-	printf "✔️ Settings updated successfully."
-	printf "\n"
+    printf "➡️ Updating settings\n"
+    modify_settings
+    source_settings
+    printf "✔️ Settings updated successfully."
+    printf "\n"
 }

--- a/4ndr0tools/4ndr0update/main.sh
+++ b/4ndr0tools/4ndr0update/main.sh
@@ -1,26 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 pkg_path() {
-	if [[ -L "$0" ]]; then
-		dirname "$(readlink $0)"
-	else
-		dirname "$0"
-	fi
+    if [[ -L "$0" ]]; then
+        dirname "$(readlink "$0")"
+    else
+        dirname "$0"
+    fi
 }
 
 check_optdepends() {
-	if [[ -n "$(command -v $1)" ]]; then
-		return 0
-	else
-		return 1
-	fi
+    if [[ -n "$(command -v "$1")" ]]; then
+        return 0
+    else
+        return 1
+    fi
 }
 
 fallback_view() {
-	printf "\n❌ Incorrect USER_INTERFACE -- falling back to default\n" 1>&2
-	read
-	source $(pkg_path)/view/dialog.sh
+    printf "\n❌ Incorrect USER_INTERFACE -- falling back to default\n" 1>&2
+    read
+    source "$(pkg_path)/view/dialog.sh"
 }
 
 repair_settings() {
@@ -31,7 +32,7 @@ repair_settings() {
 }
 
 source_settings() {
-	source $(pkg_path)/settings.sh
+    source "$(pkg_path)/settings.sh"
 }
 
 source_service() {
@@ -41,30 +42,33 @@ source_service() {
 }
 
 source_controller() {
-	source $(pkg_path)/controller.sh
+    source "$(pkg_path)/controller.sh"
 }
 
 execute_main() {
-	printf "\n"
-	main
-	test "$?" == 1 && repair_settings
+    printf "\n"
+    main
+    test "$?" == 1 && repair_settings
 }
 
 if [[ "$EUID" -ne 0 ]]; then
-#	printf "💀 Auto-escalated 💀\n"
-	sudo "$0" "$@"
-	exit $?
+    #	printf "💀 Auto-escalated 💀\n"
+    sudo "$0" "$@"
+    exit $?
 else
-	source_settings
-	source_service
-	source_controller
-fi	
-	case "$USER_INTERFACE" in
-		'cli')
-			source $(pkg_path)/view/cli.sh;;
-		'dialog')
-			source $(pkg_path)/view/dialog.sh;;
-		*)
-			fallback_view;;	
-	esac
+    source_settings
+    source_service
+    source_controller
+fi
+case "$USER_INTERFACE" in
+    'cli')
+        source "$(pkg_path)/view/cli.sh"
+        ;;
+    'dialog')
+        source "$(pkg_path)/view/dialog.sh"
+        ;;
+    *)
+        fallback_view
+        ;;
+esac
 execute_main

--- a/4ndr0tools/4ndr0update/service/arch_news.py
+++ b/4ndr0tools/4ndr0update/service/arch_news.py
@@ -17,15 +17,14 @@ def clean_html(raw_html):
 def upgrade_alerts(last_upgrade=False):
 
     url = "https://www.archlinux.org/feeds/news/"
-    file = urllib.request.urlopen(url)
-    data = file.read()
-    file.close()
+    with urllib.request.urlopen(url) as fh:
+        data = fh.read()
 
     arch_news = xmltodict.parse(data)
 
     exit_code = 0
     for news_post in arch_news["rss"]["channel"]["item"]:
-        if last_upgrade == False or parse(news_post["pubDate"]).replace(
+        if not last_upgrade or parse(news_post["pubDate"]).replace(
             tzinfo=None
         ) >= parse(last_upgrade):
             exit_code = 1

--- a/4ndr0tools/4ndr0update/service/backup.sh
+++ b/4ndr0tools/4ndr0update/service/backup.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 LOG_FILE="/var/log/4ndr0update_backup.log"
 
@@ -9,47 +10,51 @@ log_message() {
     printf "$(date '+%Y-%m-%d %H:%M:%S') - $message" | tee -a "$LOG_FILE"
 }
 
-
 # Function to execute the system backup
 execute_backup() {
-	if [[ -d "$BACKUP_LOCATION" ]]; then
-		read -r -p "Do you want to backup the system to $BACKUP_LOCATION? [y/N]"
-		if [[ "$REPLY" =~ [yY] ]]; then
-				log_message "\nBacking up the system...\n"
+    if [[ -d "$BACKUP_LOCATION" ]]; then
+        read -r -p "Do you want to backup the system to $BACKUP_LOCATION? [y/N]"
+        if [[ "$REPLY" =~ [yY] ]]; then
+            log_message "\nBacking up the system...\n"
 
-				rsync -aAXHS --info=progress2 --delete \
-				--exclude-from <(printf '%s\n' "${BACKUP_EXCLUDE[@]}") \
-				--exclude={"/swapfile","/lost+found","$BACKUP_LOCATION"} \
-                                / "$BACKUP_LOCATION" || { log_message "Error: Backup failed."; return 1; }
+            rsync -aAXHS --info=progress2 --delete \
+                --exclude-from <(printf '%s\n' "${BACKUP_EXCLUDE[@]}") \
+                --exclude={"/swapfile","/lost+found","$BACKUP_LOCATION"} \
+                / "$BACKUP_LOCATION" || {
+                log_message "Error: Backup failed."
+                return 1
+            }
 
-				touch "$BACKUP_LOCATION/verified_backup_image.lock"
-				log_message "...Done backing up to $BACKUP_LOCATION\n"
+            touch "$BACKUP_LOCATION/verified_backup_image.lock"
+            log_message "...Done backing up to $BACKUP_LOCATION\n"
 
-		fi
-	else
-		log_message "\n$BACKUP_LOCATION is not an existing directory\n"
-		read -r -p "Do you want to create backup directory at $BACKUP_LOCATION? [y/N]"
-		if [[ "$REPLY" =~ [yY] ]]; then
-			mkdir -p "$BACKUP_LOCATION"
-			execute_backup
-		fi
-	fi
+        fi
+    else
+        log_message "\n$BACKUP_LOCATION is not an existing directory\n"
+        read -r -p "Do you want to create backup directory at $BACKUP_LOCATION? [y/N]"
+        if [[ "$REPLY" =~ [yY] ]]; then
+            mkdir -p "$BACKUP_LOCATION"
+            execute_backup
+        fi
+    fi
 }
 
 execute_restore() {
-	read -r -p "Do you want to restore the system from $BACKUP_LOCATION? [y/N]"
-	if [[ "$REPLY" =~ [yY] ]]; then
-		if [[ -a "$BACKUP_LOCATION/verified_backup_image.lock" ]]; then
-                        log_message "\nStarting system restore...\n"
+    read -r -p "Do you want to restore the system from $BACKUP_LOCATION? [y/N]"
+    if [[ "$REPLY" =~ [yY] ]]; then
+        if [[ -e "$BACKUP_LOCATION/verified_backup_image.lock" ]]; then
+            log_message "\nStarting system restore...\n"
 
-
-			rsync -aAXHS --info=progress2 --delete \
-			--exclude-from <(printf '%s\n' "${BACKUP_EXCLUDE[@]}") \
-			--exclude={"/swapfile","/lost+found","/verified_backup_image.lock","$BACKUP_LOCATION"} \
-                        "$BACKUP_LOCATION/" / || { log_message "Error: Restore failed."; return 1; }
-			log_message "...Done restoring from $BACKUP_LOCATION\n"
-		else
-                        log_message "Error: No verified backup found at $BACKUP_LOCATION."
-		fi
-	fi
+            rsync -aAXHS --info=progress2 --delete \
+                --exclude-from <(printf '%s\n' "${BACKUP_EXCLUDE[@]}") \
+                --exclude={"/swapfile","/lost+found","/verified_backup_image.lock","$BACKUP_LOCATION"} \
+                "$BACKUP_LOCATION/" / || {
+                log_message "Error: Restore failed."
+                return 1
+            }
+            log_message "...Done restoring from $BACKUP_LOCATION\n"
+        else
+            log_message "Error: No verified backup found at $BACKUP_LOCATION."
+        fi
+    fi
 }

--- a/4ndr0tools/4ndr0update/service/cleanup.sh
+++ b/4ndr0tools/4ndr0update/service/cleanup.sh
@@ -1,56 +1,56 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 remove_orphaned_packages() {
-	printf "\n➡️ Checking for orphaned packages\n"
-	mapfile -t orphaned < <(pacman -Qtdq)
-	if [[ "${orphaned[*]}" ]]; then
-		printf "ORPHANED PACKAGES FOUND:\n"
-		printf '%s\n' "${orphaned[@]}"
-		read -r -p "Do you want to remove the above orphaned packages? [y/N]"
-		if [[ "$REPLY" =~ [yY] ]]; then
-			pacman -Rns --noconfirm "${orphaned[@]}"
-		fi
-	else
-		printf "...No orphaned packages found\n"
-	fi
+    printf "\n➡️ Checking for orphaned packages\n"
+    mapfile -t orphaned < <(pacman -Qtdq)
+    if [[ "${orphaned[*]}" ]]; then
+        printf "ORPHANED PACKAGES FOUND:\n"
+        printf '%s\n' "${orphaned[@]}"
+        read -r -p "Do you want to remove the above orphaned packages? [y/N]"
+        if [[ "$REPLY" =~ [yY] ]]; then
+            pacman -Rns --noconfirm "${orphaned[@]}"
+        fi
+    else
+        printf "...No orphaned packages found\n"
+    fi
 }
 
 remove_dropped_packages() {
-	printf "\nChecking for dropped packages...\n"
-	whitelist="maint"
-	for aur_pkg in "${AUR_WHITELIST[@]}"; do
-		whitelist="$whitelist|$aur_pkg"
-	done
-	if [[ -d "$AUR_DIR" ]]; then
-		for aur_pkg in "$AUR_DIR"/*/; do
-			if [[ -d "$aur_pkg" ]]; then
-				whitelist="$whitelist|$(basename "$aur_pkg")"
-			fi
-		done
-	fi
-	mapfile -t dropped < <(awk "!/${whitelist}/" <(pacman -Qmq))
+    printf "\nChecking for dropped packages...\n"
+    whitelist="maint"
+    for aur_pkg in "${AUR_WHITELIST[@]}"; do
+        whitelist="$whitelist|$aur_pkg"
+    done
+    if [[ -d "$AUR_DIR" ]]; then
+        for aur_pkg in "$AUR_DIR"/*/; do
+            if [[ -d "$aur_pkg" ]]; then
+                whitelist="$whitelist|$(basename "$aur_pkg")"
+            fi
+        done
+    fi
+    mapfile -t dropped < <(awk "!/${whitelist}/" <(pacman -Qmq))
 
-	if [[ "${dropped[*]}" ]]; then
-		printf "DROPPED PACKAGES FOUND:\n"
-		printf '%s\n' "${dropped[@]}"
-		read -r -p "Do you want to remove the above dropped packages? [y/N]"
-		if [[ "$REPLY" =~ [yY] ]]; then
-			pacman -Rns --noconfirm "${dropped[@]}"
-		fi
-	else
-		printf "...No dropped packages found\n"
-	fi
+    if [[ "${dropped[*]}" ]]; then
+        printf "DROPPED PACKAGES FOUND:\n"
+        printf '%s\n' "${dropped[@]}"
+        read -r -p "Do you want to remove the above dropped packages? [y/N]"
+        if [[ "$REPLY" =~ [yY] ]]; then
+            pacman -Rns --noconfirm "${dropped[@]}"
+        fi
+    else
+        printf "...No dropped packages found\n"
+    fi
 }
-
 
 clean_package_cache() {
     printf "\n"
     read -r -p "Do you want to clean up the package cache? [y/N] "
     if [[ "$REPLY" =~ ^[yY]$ ]]; then
-    	printf "➡️ Cleaning package cache\n"
+        printf "➡️ Cleaning package cache\n"
         paccache -r
-		printf "✔️ Package cache cleaned\n"
+        printf "✔️ Package cache cleaned\n"
     else
         printf "➡️ Skipping package cache clean.\n"
     fi
@@ -65,11 +65,11 @@ clean_broken_symlinks() {
         if [[ "${broken_symlinks[*]}" ]]; then
             printf "BROKEN SYMLINKS TO BE DELETED:\n"
             printf '%s\n' "${broken_symlinks[@]}"
-	    rm "${broken_symlinks[@]}"
-            fi
-        else
-            printf "➡️ Symlinks working appropriately\n"
+            printf '%s\0' "${broken_symlinks[@]}" | xargs -0 rm --
         fi
+    else
+        printf "➡️ Symlinks working appropriately\n"
+    fi
 }
 
 clean_old_config() {

--- a/4ndr0tools/4ndr0update/service/errors.sh
+++ b/4ndr0tools/4ndr0update/service/errors.sh
@@ -1,12 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 failed_services() {
-	printf "\nFAILED SYSTEMD SERVICES:\n"
-	systemctl --failed
+    printf "\nFAILED SYSTEMD SERVICES:\n"
+    systemctl --failed
 }
 
 journal_errors() {
-	printf "\nHIGH PRIORITY SYSTEMD JOURNAL ERRORS:\n"
-	journalctl -p 3 -xb
+    printf "\nHIGH PRIORITY SYSTEMD JOURNAL ERRORS:\n"
+    journalctl -p 3 -xb
 }

--- a/4ndr0tools/4ndr0update/service/news.sh
+++ b/4ndr0tools/4ndr0update/service/news.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 arch_news() {
     export COLUMNS

--- a/4ndr0tools/4ndr0update/service/settings.sh
+++ b/4ndr0tools/4ndr0update/service/settings.sh
@@ -1,14 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 modify_settings() {
     # Check if EDITOR is set and valid
     if [[ -z "$EDITOR" && -n "$SUDO_USER" ]]; then
-            EDITOR="$(sudo -i -u $SUDO_USER env | awk '/^EDITOR=/{ print substr($0, 8) }')"
+        EDITOR="$(sudo -i -u "$SUDO_USER" env | awk '/^EDITOR=/{ print substr($0, 8) }')"
     fi
-    
+
     if [[ -n "$EDITOR" ]]; then
-            execute_editor "$EDITOR" "\nEDITOR environment variable of $EDITOR is not valid"
+        execute_editor "$EDITOR" "\nEDITOR environment variable of $EDITOR is not valid"
     elif [[ "$SETTINGS_EDITOR" =~ (vim|neovim|nano|emacs|micro|lite-xl) && $(command -v "$SETTINGS_EDITOR") ]]; then
         execute_editor "$SETTINGS_EDITOR"
     else
@@ -35,16 +36,37 @@ execute_editor() {
 # Function to prompt user for available editors if both EDITOR and SETTINGS_EDITOR fail
 fallback_editor() {
     printf "\nNo valid editor found. Please select an editor to use\n" 1>&2
-    select editor in "vim" "neovim" "nano" "emacs" "micro" "lite-xl" "Exit"; do
+    select editor in "vim" "nvim" "nano" "emacs" "micro" "lite-xl" "Exit"; do
         case $REPLY in
-            1) vim "$(pkg_path)/settings.sh"; break;;
-            2) neovimn "$(pkg_path)/settings.sh"; break;;
-            3) nano "$(pkg_path)/settings.sh"; break;;
-	    4) emacs "$(pkg_path)/settings.sh"; break;;
-            5) micro "$(pkg_path)/settings.sh"; break;;
-            6) lite-xl "$(pkg_path)/settings.sh"; break;;
-            7) echo "Exiting without modifying settings."; exit 0;;
-            *) echo "Invalid selection. Please choose again.";;
+            1)
+                vim "$(pkg_path)/settings.sh"
+                break
+                ;;
+            2)
+                nvim "$(pkg_path)/settings.sh"
+                break
+                ;;
+            3)
+                nano "$(pkg_path)/settings.sh"
+                break
+                ;;
+            4)
+                emacs "$(pkg_path)/settings.sh"
+                break
+                ;;
+            5)
+                micro "$(pkg_path)/settings.sh"
+                break
+                ;;
+            6)
+                lite-xl "$(pkg_path)/settings.sh"
+                break
+                ;;
+            7)
+                echo "Exiting without modifying settings."
+                exit 0
+                ;;
+            *) echo "Invalid selection. Please choose again." ;;
         esac
     done
 }

--- a/4ndr0tools/4ndr0update/service/upgrade.sh
+++ b/4ndr0tools/4ndr0update/service/upgrade.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 # Maximum retries for system commands
 MAX_RETRIES=3
-RETRY_DELAY=2  # seconds
+RETRY_DELAY=2 # seconds
 
 # Function to retry a command with a delay if it fails
 retry_command() {
@@ -12,7 +13,10 @@ retry_command() {
     local cmd="$*"
 
     until $cmd; do
-        ((retries--)) || { echo "Error: Command failed after $MAX_RETRIES attempts: $cmd"; exit 1; }
+        ((retries--)) || {
+            echo "Error: Command failed after $MAX_RETRIES attempts: $cmd"
+            exit 1
+        }
         echo "Retrying... ($retries attempts left)"
         sleep "$delay"
     done
@@ -23,34 +27,32 @@ configure_reflector() {
     read -r -p "Update Mirrorlist? [y/N]"
 
     if [[ "$REPLY" =~ [yY] ]]; then
-		reflector --country "$MIRRORLIST_COUNTRY" --latest 200 --age 24 --sort rate --save /etc/pacman.d/mirrorlist
-		printf "✔️ Mirrorlist updated\n"
+        reflector --country "$MIRRORLIST_COUNTRY" --latest 200 --age 24 --sort rate --save /etc/pacman.d/mirrorlist
+        printf "✔️ Mirrorlist updated\n"
     fi
-    
-	if ! systemctl is-enabled reflector.timer > /dev/null 2>&1; then
-		sudo systemctl enable --now reflector.timer
-		printf "➡️ Checking Reflector Service...\n"
-	else
-    	printf "✔️ Already Enabled\n"
-	fi
-}
 
+    if ! systemctl is-enabled reflector.timer >/dev/null 2>&1; then
+        sudo systemctl enable --now reflector.timer
+        printf "➡️ Checking Reflector Service...\n"
+    else
+        printf "✔️ Already Enabled\n"
+    fi
+}
 
 system_update() {
     printf "\n➡️ Updating system\n"
-    retry_command sudo /usr/bin/pacman -Syyu
     if ! retry_command sudo /usr/bin/pacman -Syyu; then
         echo "❌ System update failed."
         return 1
     else
-    	printf "✔️ Update complete\n"
+        printf "✔️ Update complete\n"
     fi
 }
 
 # Function to check and install a package if it is missing
 ensure_package_installed() {
     local pkg="$1"
-    if ! pacman -Qs "$pkg" > /dev/null; then
+    if ! pacman -Qs "$pkg" >/dev/null; then
         printf "➡️ Installing $pkg "
         retry_command sudo pacman -S --noconfirm "$pkg"
     else
@@ -73,63 +75,62 @@ check_and_install_dependencies() {
 
 # Set up AUR directory using the chosen AUR helper (from settings.sh)
 aur_setup() {
-	printf "\n"
-	read -r -p "Do you want to setup the AUR package directory at $AUR_DIR? [y/N]"
-	if [[ "$REPLY" =~ [yY] ]]; then
-		printf "➡️ Setting up AUR package directory...\n"
-		if [[ ! -d "$AUR_DIR" ]]; then
-			mkdir -p "$AUR_DIR"
-			test -n "$SUDO_USER" && chown "$SUDO_USER" "$AUR_DIR"
-		fi
+    printf "\n"
+    read -r -p "Do you want to setup the AUR package directory at $AUR_DIR? [y/N]"
+    if [[ "$REPLY" =~ [yY] ]]; then
+        printf "➡️ Setting up AUR package directory...\n"
+        if [[ ! -d "$AUR_DIR" ]]; then
+            mkdir -p "$AUR_DIR"
+            test -n "$SUDO_USER" && chown "$SUDO_USER" "$AUR_DIR"
+        fi
 
-		chgrp "$1" "$AUR_DIR"
-		chmod g+ws "$AUR_DIR"
-		setfacl -d --set u::rwx,g::rx,o::rx "$AUR_DIR"
-		setfacl -m u::rwx,g::rwx,o::- "$AUR_DIR"
-		printf "...AUR package directory set up at $AUR_DIR\n"
-	fi
+        chgrp "$1" "$AUR_DIR"
+        chmod g+ws "$AUR_DIR"
+        setfacl -d --set u::rwx,g::rx,o::rx "$AUR_DIR"
+        setfacl -m u::rwx,g::rwx,o::- "$AUR_DIR"
+        printf "...AUR package directory set up at $AUR_DIR\n"
+    fi
 }
 
 rebuild_aur() {
-	AUR_DIR_GROUP="nobody"
-	test -n "$SUDO_USER" && AUR_DIR_GROUP="$SUDO_USER"
+    AUR_DIR_GROUP="nobody"
+    test -n "$SUDO_USER" && AUR_DIR_GROUP="$SUDO_USER"
 
-	if [[ -w "$AUR_DIR" ]] && sudo -u "$AUR_DIR_GROUP" test -w "$AUR_DIR"; then
-		printf "\n"
-		read -r -p "Do you want to rebuild the AUR packages in $AUR_DIR? [y/N]"
-		if [[ "$REPLY" =~ [yY] ]]; then
-			printf "➡️ Rebuilding AUR packages...\n"
-			if [[ -n "$(ls -A $AUR_DIR)" ]]; then
-				starting_dir="$(pwd)"
-				for aur_pkg in "$AUR_DIR"/*/; do
-					if [[ -d "$aur_pkg" ]]; then
-						if ! sudo -u "$AUR_DIR_GROUP" test -w "$aur_pkg"; then
-							chmod -R g+w "$aur_pkg"
-						fi
-						cd "$aur_pkg"
-						if [[ "$AUR_UPGRADE" == "true" ]]; then
-							git pull origin master
-						fi
-						source PKGBUILD
-						pacman -S --needed --asdeps "${depends[@]}" "${makedepends[@]}" --noconfirm
-						sudo -u "$AUR_DIR_GROUP" makepkg -fc --noconfirm
-						pacman -U "$(sudo -u $AUR_DIR_GROUP makepkg --packagelist)" --noconfirm
-					fi
-				done
-				cd "$starting_dir"
-				printf "Done rebuilding AUR packages\n"
-			else
-				printf "No AUR packages in $AUR_DIR\n"
-			fi
-		fi
-	else
-		printf "\nAUR package directory not set up"
-		aur_setup "$AUR_DIR_GROUP"
-	fi
+    if [[ -w "$AUR_DIR" ]] && sudo -u "$AUR_DIR_GROUP" test -w "$AUR_DIR"; then
+        printf "\n"
+        read -r -p "Do you want to rebuild the AUR packages in $AUR_DIR? [y/N]"
+        if [[ "$REPLY" =~ [yY] ]]; then
+            printf "➡️ Rebuilding AUR packages...\n"
+            if [[ -n "$(ls -A $AUR_DIR)" ]]; then
+                starting_dir="$(pwd)"
+                for aur_pkg in "$AUR_DIR"/*/; do
+                    if [[ -d "$aur_pkg" ]]; then
+                        if ! sudo -u "$AUR_DIR_GROUP" test -w "$aur_pkg"; then
+                            chmod -R g+w "$aur_pkg"
+                        fi
+                        cd "$aur_pkg"
+                        if [[ "$AUR_UPGRADE" == "true" ]]; then
+                            git pull origin master
+                        fi
+                        source PKGBUILD
+                        pacman -S --needed --asdeps "${depends[@]}" "${makedepends[@]}" --noconfirm
+                        sudo -u "$AUR_DIR_GROUP" makepkg -fc --noconfirm
+                        pacman -U "$(sudo -u $AUR_DIR_GROUP makepkg --packagelist)" --noconfirm
+                    fi
+                done
+                cd "$starting_dir"
+                printf "Done rebuilding AUR packages\n"
+            else
+                printf "No AUR packages in $AUR_DIR\n"
+            fi
+        fi
+    else
+        printf "\nAUR package directory not set up"
+        aur_setup "$AUR_DIR_GROUP"
+    fi
 }
 
 handle_pacfiles() {
-	printf "➡️ Checking for pacfiles\n"
-	pacdiff
+    printf "➡️ Checking for pacfiles\n"
+    pacdiff
 }
-

--- a/4ndr0tools/4ndr0update/service/util.sh
+++ b/4ndr0tools/4ndr0update/service/util.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 # Maximum retries for system commands
 MAX_RETRIES=3
-RETRY_DELAY=2  # seconds
+RETRY_DELAY=2 # seconds
 
 # Function to retry a command with a delay if it fails
 retry_command() {
@@ -12,7 +13,10 @@ retry_command() {
     local cmd="$*"
 
     until $cmd; do
-        ((retries--)) || { echo "Error: Command failed after $MAX_RETRIES attempts: $cmd"; return 1; }
+        ((retries--)) || {
+            echo "Error: Command failed after $MAX_RETRIES attempts: $cmd"
+            return 1
+        }
         echo "Retrying... ($retries attempts left)"
         sleep "$delay"
     done

--- a/4ndr0tools/4ndr0update/view/cli.sh
+++ b/4ndr0tools/4ndr0update/view/cli.sh
@@ -1,26 +1,27 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 main() {
     if [[ "$EUID" -eq 0 ]]; then
-    printf "\n"
-    
-    PS3='Option (press enter for menu): '
-    select opt in "Update" "Clean" "Journal Errors" "Create Backup" "Restore Backup" "Vacuum.py" "Settings" "Exit"; do
-        case $REPLY in
-            1) system_upgrade;;
-            2) system_clean;;
-	    3) system_errors;;
-            4) backup_system;;
-            5) restore_system;;
-            6)
-               # Run the vacuum.py script from the service directory
-               python3 "$(pkg_path)/service/vacuum.py"
-               ;;
-            7) update_settings;;
-            8) break;;
-            *) printf "Please choose an existing option";;
-        esac
-    done
+        printf "\n"
+
+        PS3='Option (press enter for menu): '
+        select opt in "Update" "Clean" "Journal Errors" "Create Backup" "Restore Backup" "Vacuum.py" "Settings" "Exit"; do
+            case $REPLY in
+                1) system_upgrade ;;
+                2) system_clean ;;
+                3) system_errors ;;
+                4) backup_system ;;
+                5) restore_system ;;
+                6)
+                    # Run the vacuum.py script from the service directory
+                    python3 "$(pkg_path)/service/vacuum.py"
+                    ;;
+                7) update_settings ;;
+                8) break ;;
+                *) printf "Please choose an existing option" ;;
+            esac
+        done
     fi
 }

--- a/4ndr0tools/4ndr0update/view/dialog.sh
+++ b/4ndr0tools/4ndr0update/view/dialog.sh
@@ -1,39 +1,60 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=all
+set -euo pipefail
 
 check_exit() {
-	printf "Done - Press enter to continue\n";
-	read
+    printf "Done - Press enter to continue\n"
+    read
 }
 
-main () {
-	if [[ "$EUID" -eq 0 ]]; then
-		while true; do
-			REPLY=$(dialog --stdout --title "4ndr0update" --menu "By Your Command:" 15 50 8 \
-					1 "Update" \
-					2 "Clean" \
-					3 "Journal Errors" \
-					4 "Create Backup" \
-					5 "Restore Backup" \
-					6 "Vacuum.py" \
-					7 "Settings" \
-					0 "Exit")
-			clear;
-			case "$REPLY" in
-				1) system_upgrade   
-				2) system_clean; check_exit;;
-				3) system_errors; check_exit;;
-				4) backup_system; check_exit;;
-				5) restore_system; check_exit;;
-				6) python3 $(pkg_path)/service/vacuum.py; check_exit;;
-				7) update_settings;;
-				0) dialog --stdout --title "Confirm Exit" --yesno "Are you sure you want to exit?" 7 40
-				   if [[ $? -eq 0 ]]; then
-				       clear
-				       exit
-				   fi;;
-				*) clear; exit;;
-			esac
-		done
-	fi
+main() {
+    if [[ "$EUID" -eq 0 ]]; then
+        while true; do
+            REPLY=$(dialog --stdout --title "4ndr0update" --menu "By Your Command:" 15 50 8 \
+                1 "Update" \
+                2 "Clean" \
+                3 "Journal Errors" \
+                4 "Create Backup" \
+                5 "Restore Backup" \
+                6 "Vacuum.py" \
+                7 "Settings" \
+                0 "Exit")
+            clear
+            case "$REPLY" in
+                1) system_upgrade ;;
+                2)
+                    system_clean
+                    check_exit
+                    ;;
+                3)
+                    system_errors
+                    check_exit
+                    ;;
+                4)
+                    backup_system
+                    check_exit
+                    ;;
+                5)
+                    restore_system
+                    check_exit
+                    ;;
+                6)
+                    python3 "$(pkg_path)/service/vacuum.py"
+                    check_exit
+                    ;;
+                7) update_settings ;;
+                0)
+                    dialog --stdout --title "Confirm Exit" --yesno "Are you sure you want to exit?" 7 40
+                    if [[ $? -eq 0 ]]; then
+                        clear
+                        exit
+                    fi
+                    ;;
+                *)
+                    clear
+                    exit
+                    ;;
+            esac
+        done
+    fi
 }


### PR DESCRIPTION
## Summary
- expand `ANALYSIS.md` with rewrite approach, rating and bug fixes
- apply strict mode and quoting fixes across 4ndr0update scripts
- clean dead code from controller, fix typos and duplicate pacman call
- improve cleanup safety and RSS fetching

## Testing
- `shellcheck 4ndr0tools/4ndr0update/*.sh 4ndr0tools/4ndr0update/service/*.sh 4ndr0tools/4ndr0update/view/*.sh`
- `shfmt -i 4 -ci -w 4ndr0tools/4ndr0update/*.sh 4ndr0tools/4ndr0update/service/*.sh 4ndr0tools/4ndr0update/view/*.sh`
- `ruff check 4ndr0tools/4ndr0update/service/arch_news.py`
- `bats 0-tests/bats/test-codex-merge-clean.bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f13ae504832e9f15263dd145ccf3