### PR TITLE
Implement ffxd CLI skeleton

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -24,3 +24,4 @@
 2025-06-23 • 4ndr0tools/4ndr0update/ANALYSIS.md • +49/-63 • Expand review with rewrite approach and improvements
 2025-06-23 • 4ndr0tools/4ndr0update/* • +366/-365 • Apply strict mode, fix bugs, and clean dead code
 
+2025-06-24 • media/ffx_project/bin/ffxd • +129/-0 • Initial unified CLI skeleton

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -14,3 +14,4 @@ Unified deps script with ignore lists and feature matrix.
 Added analysis for 4ndr0update utility suite.
 Expanded analysis for 4ndr0update with detailed rating and bug fixes.
 Implemented Step 2 items: added strict mode, quoting fixes, removed dead code, fixed typos and duplicate commands.
+Created ffxd skeleton with global option parsing.

--- a/media/ffx_project/bin/ffxd
+++ b/media/ffx_project/bin/ffxd
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# ffxd - Unified CLI for the Ffx project
+# shellcheck disable=SC2034
+# Implements global option parsing and stub commands
+# Requires bash 5+
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# --- XDG setup ---
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+
+# create runtime dir if missing
+mkdir -p "$XDG_RUNTIME_DIR/ffxd"
+TEMP_DIR="$(mktemp -d "$XDG_RUNTIME_DIR/ffxd/ffxd.XXXX")"
+trap 'rm -rf -- "$TEMP_DIR"' EXIT
+
+# --- global flags ---
+ADVANCED=false
+VERBOSE=false
+BULK=false
+NOAUDIO=false
+COMPOSITE=false
+MAX1080=false
+OUTPUT_DIR="$(pwd)"
+FPS=""
+PTS=""
+INTERPOLATE=false
+
+parse_global_options() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-a | --advanced) ADVANCED=true ;;
+		-v | --verbose) VERBOSE=true ;;
+		-b | --bulk) BULK=true ;;
+		-n | --noaudio) NOAUDIO=true ;;
+		-c | --composite) COMPOSITE=true ;;
+		-m | --max1080) MAX1080=true ;;
+		-o | --output-dir)
+			OUTPUT_DIR="$2"
+			shift
+			;;
+		-f | --fps)
+			FPS="$2"
+			shift
+			;;
+		-p | --pts)
+			PTS="$2"
+			shift
+			;;
+		-i | --interpolate) INTERPOLATE=true ;;
+		--)
+			shift
+			break
+			;;
+		*)
+			break
+			;;
+		esac
+		shift
+	done
+	GLOBAL_ARGS_LEFT=("$@")
+}
+
+show_help() {
+	cat <<EOH
+Usage: ffxd [global options] <command> [args]
+Commands: process merge composite looperang slowmo fix clean probe help
+Global options:
+  -a, --advanced        Interactive advanced prompt
+  -v, --verbose         Verbose output
+  -b, --bulk            Bulk mode where supported
+  -n, --noaudio         Remove audio streams
+  -c, --composite       Composite grid output
+  -m, --max1080         Enforce 1080p maximum height
+  -o, --output-dir DIR  Output directory
+  -f, --fps FPS         Force frame rate
+  -p, --pts FACTOR      Playback speed factor
+  -i, --interpolate     Enable motion interpolation
+EOH
+}
+
+cmd_process() { echo "process not implemented"; }
+cmd_merge() { echo "merge not implemented"; }
+cmd_composite() { echo "composite not implemented"; }
+cmd_looperang() { echo "looperang not implemented"; }
+cmd_slowmo() { echo "slowmo not implemented"; }
+cmd_fix() { echo "fix not implemented"; }
+cmd_clean() { echo "clean not implemented"; }
+cmd_probe() { echo "probe not implemented"; }
+
+main() {
+	parse_global_options "$@"
+	local cmd="${GLOBAL_ARGS_LEFT[0]:-help}"
+	shift $((${#GLOBAL_ARGS_LEFT[@]} > 0 ? 1 : 0))
+	case "$cmd" in
+	process) cmd_process "$@" ;;
+	merge) cmd_merge "$@" ;;
+	composite) cmd_composite "$@" ;;
+	looperang) cmd_looperang "$@" ;;
+	slowmo) cmd_slowmo "$@" ;;
+	fix) cmd_fix "$@" ;;
+	clean) cmd_clean "$@" ;;
+	probe) cmd_probe "$@" ;;
+	help | -h | --help) show_help ;;
+	*)
+		echo "Unknown command: $cmd" >&2
+		show_help
+		exit 1
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add initial `ffxd` script with global option parsing
- log the addition in CHANGELOG
- update task outcome notes

## Testing
- `shellcheck media/ffx_project/bin/ffxd`
- `shfmt -d media/ffx_project/bin/ffxd`
- `bats 0-tests/bats/test-codex-merge-clean.bats` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b02dbce5c832eae1f96983d956909