### PR TITLE
Resolve merge conflict in install_env_maintenance

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -27,3 +27,4 @@
 2025-06-24 • media/ffx_project/bin/ffxd • +129/-0 • Initial unified CLI skeleton
 2025-06-25 • media/ffx_project/ffxd • +1052/-0 • Implement advanced prompt, auto-increment output, enhanced composite grid, clean options, and multi-stage atempo
 2025-07-03 • media/dmx_project/dmxbeta • +18/-8 • Add Batch Enhance UI handler
+2025-07-11 • 4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh • +0/-10 • Remove merge markers and finalize installation logic

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -17,3 +17,4 @@ Implemented Step 2 items: added strict mode, quoting fixes, removed dead code, f
 Created ffxd skeleton with global option parsing.
 Implemented major features from ffxd CODEX including advanced prompt, output idempotency, composite grid generalization, clean enhancements, and multi-stage atempo.
 Implemented DMX-101 batch enhance menu option
+Fixed merge conflict markers in install_env_maintenance.sh and ensured script installs verify_environment.sh correctly.

--- a/4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh
+++ b/4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh
@@ -15,19 +15,9 @@ ensure_dir "$SYSTEMD_USER_DIR"
 # Install verify_environment.sh into ~/.local/bin for unit invocation
 LOCAL_BIN="$HOME/.local/bin"
 ensure_dir "$LOCAL_BIN"
-<<<<<<< HEAD
-
-if install -Dm755 "$PKG_PATH/test/src/verify_environment.sh" \
-	"$LOCAL_BIN/verify_environment.sh"; then
-	echo "Installed $LOCAL_BIN/verify_environment.sh"
-else
-	echo "Warning: failed to install verify_environment.sh" >&2
-fi
-=======
 cp -f "$PKG_PATH/test/src/verify_environment.sh" "$LOCAL_BIN/verify_environment.sh"
 chmod +x "$LOCAL_BIN/verify_environment.sh"
 echo "Installed $LOCAL_BIN/verify_environment.sh"
->>>>>>> 4e8d685 (Fix executable mode)
 
 # Copy or symlink units
 install_unit() {


### PR DESCRIPTION
## Summary
- remove leftover merge markers from install_env_maintenance.sh
- ensure verify_environment.sh installs using cp and chmod
- update CHANGELOG and task outcome

## Testing
- `shellcheck 4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh`
- `shfmt -d 4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh`
- `pytest -q`
- `bats 0-tests/bats` *(fails: `codex-merge-clean.sh` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717d31deec832e94364c7d4e5c0093