### PR TITLE
Enable shellcheck for 4ndr0service scripts

### DIFF
--- a/0-tests/CHANGELOG.md
+++ b/0-tests/CHANGELOG.md
@@ -27,3 +27,4 @@
 2025-06-24 • media/ffx_project/bin/ffxd • +129/-0 • Initial unified CLI skeleton
 2025-06-25 • media/ffx_project/ffxd • +1052/-0 • Implement advanced prompt, auto-increment output, enhanced composite grid, clean options, and multi-stage atempo
 2025-07-03 • media/dmx_project/dmxbeta • +18/-8 • Add Batch Enhance UI handler
+2025-07-11 • 4ndr0tools/4ndr0service/* • +71/-70 • Remove global shellcheck disables and fix lint issues

--- a/0-tests/task_outcome.md
+++ b/0-tests/task_outcome.md
@@ -17,3 +17,4 @@ Implemented Step 2 items: added strict mode, quoting fixes, removed dead code, f
 Created ffxd skeleton with global option parsing.
 Implemented major features from ffxd CODEX including advanced prompt, output idempotency, composite grid generalization, clean enhancements, and multi-stage atempo.
 Implemented DMX-101 batch enhance menu option
+Removed global shellcheck disable lines from 4ndr0service scripts and fixed lint warnings.

--- a/4ndr0tools/4ndr0service/common.sh
+++ b/4ndr0tools/4ndr0service/common.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 set -euo pipefail
 IFS=$'\n\t'
 # ================= // COMMON.SH//

--- a/4ndr0tools/4ndr0service/controller.sh
+++ b/4ndr0tools/4ndr0service/controller.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: controller.sh
 # Central controller for the 4ndr0service Suite.
 
@@ -10,11 +9,15 @@ IFS=$'\n\t'
 
 ### Constants
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/common.sh"
 ensure_pkg_path
 
+# shellcheck source=4ndr0tools/4ndr0service/settings_functions.sh
 source "$PKG_PATH/settings_functions.sh"
+# shellcheck source=4ndr0tools/4ndr0service/manage_files.sh
 source "$PKG_PATH/manage_files.sh"
+# shellcheck source=4ndr0tools/4ndr0service/test/src/verify_environment.sh
 source "$PKG_PATH/test/src/verify_environment.sh"
 
 # Set the plugins directory, defaulting to the bundled plugins folder
@@ -28,12 +31,13 @@ load_plugins() {
 		log_warn "Plugins directory '$plugins_dir' not found. Skipping."
 		return
 	fi
-	for plugin in "$plugins_dir"/*.sh; do
-		if [[ -f "$plugin" ]]; then
-			source "$plugin" || log_warn "Failed to load plugin '$plugin'."
-			log_info "Loaded plugin: $plugin"
-		fi
-	done
+        for plugin in "$plugins_dir"/*.sh; do
+                if [[ -f "$plugin" ]]; then
+                        # shellcheck disable=SC1090
+                        source "$plugin" || log_warn "Failed to load plugin '$plugin'."
+                        log_info "Loaded plugin: $plugin"
+                fi
+        done
 }
 
 source_all_services() {
@@ -41,20 +45,22 @@ source_all_services() {
 	if [[ ! -d "$services_dir" ]]; then
 		handle_error "Services directory '$services_dir' does not exist."
 	fi
-	for script in "$services_dir"/optimize_*.sh; do
-		if [[ -f "$script" ]]; then
-			source "$script" || log_warn "Failed to source '$script'."
-			log_info "Sourced service script: '$script'."
-		fi
-	done
+        for script in "$services_dir"/optimize_*.sh; do
+                if [[ -f "$script" ]]; then
+                        # shellcheck disable=SC1090
+                        source "$script" || log_warn "Failed to source '$script'."
+                        log_info "Sourced service script: '$script'."
+                fi
+        done
 }
 
 source_views() {
 	case "$USER_INTERFACE" in
 	cli)
 		local cli_script="$PKG_PATH/view/cli.sh"
-		if [[ -f "$cli_script" ]]; then
-			source "$cli_script" || handle_error "Failed to source '$cli_script'."
+                if [[ -f "$cli_script" ]]; then
+                        # shellcheck disable=SC1090
+                        source "$cli_script" || handle_error "Failed to source '$cli_script'."
 			log_info "Sourced CLI interface script."
 			main_cli
 		else
@@ -63,8 +69,9 @@ source_views() {
 		;;
 	dialog)
 		local dialog_script="$PKG_PATH/view/dialog.sh"
-		if [[ -f "$dialog_script" ]]; then
-			source "$dialog_script" || handle_error "Failed to source '$dialog_script'."
+                if [[ -f "$dialog_script" ]]; then
+                        # shellcheck disable=SC1090
+                        source "$dialog_script" || handle_error "Failed to source '$dialog_script'."
 			log_info "Sourced Dialog interface script."
 			main_dialog
 		else

--- a/4ndr0tools/4ndr0service/main.sh
+++ b/4ndr0tools/4ndr0service/main.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: main.sh
 # Entry point for the 4ndr0service Suite.
 
@@ -11,11 +10,14 @@ IFS=$'\n\t'
 ### Constants
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
 
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/common.sh"
 ensure_pkg_path
 
 # Source core modules
+# shellcheck source=4ndr0tools/4ndr0service/controller.sh
 source "$PKG_PATH/controller.sh"
+# shellcheck source=4ndr0tools/4ndr0service/manage_files.sh
 source "$PKG_PATH/manage_files.sh"
 
 ### Help

--- a/4ndr0tools/4ndr0service/manage_files.sh
+++ b/4ndr0tools/4ndr0service/manage_files.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: manage_files.sh
 # Provides batch execution of services and optional backup steps.
 
@@ -10,6 +9,7 @@ IFS=$'\n\t'
 
 ### Constants
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/common.sh"
 ensure_pkg_path
 
@@ -112,7 +112,8 @@ manage_files_main() {
 		"Optional Backups"
 		"Exit"
 	)
-	select opt in "${options[@]}"; do
+        # shellcheck disable=SC2034
+        select opt in "${options[@]}"; do
 		case "$REPLY" in
 		1) batch_execute_all ;;
 		2) batch_execute_all_parallel ;;

--- a/4ndr0tools/4ndr0service/plugins/sample_check.sh
+++ b/4ndr0tools/4ndr0service/plugins/sample_check.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: plugins/sample_check.sh
 # Description: A sample plugin that demonstrates a real, production-ready check.
 #   - In practice, you can create multiple plugins in this directory, each focusing

--- a/4ndr0tools/4ndr0service/service/optimize_cargo.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_cargo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_cargo.sh
 # Description: Rust/Cargo environment optimization (XDG-compliant, Arch Linux).
 
@@ -7,9 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-CYAN='\033[0;36m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
@@ -47,7 +45,8 @@ install_rustup() {
 	echo -e "${CYAN}📦 Installing rustup...${NC}"
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path ||
 		handle_error "rustup install failed."
-	[ -s "$CARGO_HOME/env" ] && source "$CARGO_HOME/env" || handle_error "Failed sourcing rustup env."
+        # shellcheck disable=SC1091
+        [ -s "$CARGO_HOME/env" ] && source "$CARGO_HOME/env" || handle_error "Failed sourcing rustup env."
 	log "rustup installed."
 }
 

--- a/4ndr0tools/4ndr0service/service/optimize_electron.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_electron.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_electron.sh
 # Description: Electron environment optimization (XDG-compliant).
 
@@ -7,9 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-CYAN='\033[0;36m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 

--- a/4ndr0tools/4ndr0service/service/optimize_go.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_go.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_go.sh
 # Author: 4ndr0666
 # Date: 2024-11-24
@@ -8,7 +8,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-CYAN='\033[0;36m'
 RED='\033[0;31m'
 NC='\033[0m'
 

--- a/4ndr0tools/4ndr0service/service/optimize_meson.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_meson.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_meson.sh
 # Description: Meson & Ninja build tools optimization (XDG-compliant).
 
@@ -8,6 +8,7 @@ IFS=$'\n\t'
 
 # Determine PKG_PATH and source common utilities
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/../common.sh"
 ensure_pkg_path
 

--- a/4ndr0tools/4ndr0service/service/optimize_node.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_node.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: optimize_node.sh
 # Description: Node.js environment optimization for the 4ndr0service suite.
 # Ensures Node.js (via nvm) and global CLI tools are set up using XDG directories.
@@ -9,6 +8,7 @@ IFS=$'\n\t'
 
 # Establish PKG_PATH and source common utilities
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/../common.sh"
 ensure_pkg_path
 
@@ -19,16 +19,16 @@ export NODE_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/node"
 
 # Ensure nvm is installed and loaded
 install_nvm() {
-	if [[ -s "$NVM_DIR/nvm.sh" ]]; then
-		# shellcheck disable=SC1090
-		source "$NVM_DIR/nvm.sh"
+        if [[ -s "$NVM_DIR/nvm.sh" ]]; then
+                # shellcheck disable=SC1090,SC1091
+                source "$NVM_DIR/nvm.sh"
 		log_info "NVM loaded from $NVM_DIR/nvm.sh"
 		return 0
 	fi
 	log_info "NVM not found, installing via official installer..."
-	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-	# shellcheck disable=SC1090
-	source "$NVM_DIR/nvm.sh"
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+        # shellcheck disable=SC1090,SC1091
+        source "$NVM_DIR/nvm.sh"
 	log_info "NVM installed and loaded."
 }
 
@@ -65,7 +65,9 @@ optimize_node_service() {
 	install_global_npm_tools
 
 	# Set NODE_PATH for globally installed node modules
-	export NODE_PATH="$(npm root -g)"
+        local global_node_path
+        global_node_path="$(npm root -g)"
+        export NODE_PATH="$global_node_path"
 
 	log_info "Node.js environment optimization complete."
 	log_info "Node: $(node --version 2>/dev/null || echo 'not found')"

--- a/4ndr0tools/4ndr0service/service/optimize_nvm.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_nvm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_nvm.sh
 # Description: Standalone NVM environment optimization (XDG-compliant).
 
@@ -7,8 +7,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-CYAN='\033[0;36m'
-YELLOW='\033[1;33m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
@@ -65,8 +63,11 @@ install_nvm_for_nvm_service() {
 	export PROVIDED_VERSION="" # avoid unbound in older nvm
 
 	set +u
-	[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || handle_error "Failed sourcing nvm.sh post-install."
-	[ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion" || handle_error "Failed sourcing nvm bash_completion."
+        # shellcheck disable=SC1091
+        # shellcheck disable=SC1091
+        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || handle_error "Failed sourcing nvm.sh post-install."
+        # shellcheck disable=SC1091
+        [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion" || handle_error "Failed sourcing nvm bash_completion."
 	set -u
 
 	if command -v nvm &>/dev/null; then
@@ -93,7 +94,8 @@ optimize_nvm_service() {
 	export PROVIDED_VERSION=""
 
 	set +u
-	[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || handle_error "Failed to source NVM script."
+        # shellcheck disable=SC1091
+        [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" || handle_error "Failed to source NVM script."
 	set -u
 
 	echo "🔄 Installing latest LTS Node.js via NVM..."

--- a/4ndr0tools/4ndr0service/service/optimize_python.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_python.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: optimize_python.sh
 # Production-grade Python toolchain bootstrapper for 4ndr0service
 
@@ -8,6 +7,7 @@ IFS=$'\n\t'
 
 # Determine PKG_PATH and source common environment
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+# shellcheck source=4ndr0tools/4ndr0service/common.sh
 source "$SCRIPT_DIR/../common.sh"
 ensure_pkg_path
 

--- a/4ndr0tools/4ndr0service/service/optimize_ruby.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_ruby.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_ruby.sh
 # Description: Ruby environment optimization (XDG-compliant).
 
@@ -7,7 +7,6 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-CYAN='\033[0;36m'
 RED='\033[0;31m'
 NC='\033[0m'
 

--- a/4ndr0tools/4ndr0service/service/optimize_venv.sh
+++ b/4ndr0tools/4ndr0service/service/optimize_venv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
+# shellcheck disable=SC2015
 # File: optimize_venv.sh
 # Description: Python venv & pipx optimization (XDG-compliant).
 
@@ -7,9 +7,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Colors
-CYAN='\033[0;36m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
@@ -69,7 +67,8 @@ optimize_venv_service() {
 		echo "Venv already exists at $VENV_PATH."
 	fi
 
-	source "$VENV_PATH/bin/activate" || handle_error "Failed activating venv."
+        # shellcheck disable=SC1091
+        source "$VENV_PATH/bin/activate" || handle_error "Failed activating venv."
 
 	pip install --upgrade pip || log "Warning: pip upgrade failed."
 

--- a/4ndr0tools/4ndr0service/settings_functions.sh
+++ b/4ndr0tools/4ndr0service/settings_functions.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: settings_functions.sh
 # Description: Functions to modify/manage settings for 4ndr0service Suite.
 

--- a/4ndr0tools/4ndr0service/test/final_audit.sh
+++ b/4ndr0tools/4ndr0service/test/final_audit.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: final_audit.sh
 # Description: Performs a comprehensive environment audit and final checks.
 

--- a/4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh
+++ b/4ndr0tools/4ndr0service/test/src/install_env_maintenance.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # 4ndr0service Systemd Env Maintenance Installer
 set -euo pipefail
 
@@ -7,6 +6,7 @@ set -euo pipefail
 PKG_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # shellcheck source=../common.sh
+# shellcheck disable=SC1091
 source "$PKG_PATH/common.sh"
 
 SYSTEMD_USER_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
@@ -15,7 +15,6 @@ ensure_dir "$SYSTEMD_USER_DIR"
 # Install verify_environment.sh into ~/.local/bin for unit invocation
 LOCAL_BIN="$HOME/.local/bin"
 ensure_dir "$LOCAL_BIN"
-<<<<<<< HEAD
 
 if install -Dm755 "$PKG_PATH/test/src/verify_environment.sh" \
 	"$LOCAL_BIN/verify_environment.sh"; then
@@ -23,18 +22,14 @@ if install -Dm755 "$PKG_PATH/test/src/verify_environment.sh" \
 else
 	echo "Warning: failed to install verify_environment.sh" >&2
 fi
-=======
-cp -f "$PKG_PATH/test/src/verify_environment.sh" "$LOCAL_BIN/verify_environment.sh"
-chmod +x "$LOCAL_BIN/verify_environment.sh"
-echo "Installed $LOCAL_BIN/verify_environment.sh"
->>>>>>> 4e8d685 (Fix executable mode)
 
 # Copy or symlink units
 install_unit() {
-	local src="$1"
-	local dest="$SYSTEMD_USER_DIR/$(basename "$src")"
-	cp -f "$src" "$dest"
-	echo "Installed $dest"
+        local src="$1"
+        local dest
+        dest="$SYSTEMD_USER_DIR/$(basename "$src")"
+        cp -f "$src" "$dest"
+        echo "Installed $dest"
 }
 
 # Install units

--- a/4ndr0tools/4ndr0service/test/src/verify_environment.sh
+++ b/4ndr0tools/4ndr0service/test/src/verify_environment.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: verify_environment.sh
 # Verifies/fixes environment for 4ndr0service Suite.
 # Usage: verify_environment.sh [--report] [--fix]
@@ -30,7 +29,10 @@ fi
 export PKG_PATH
 
 # shellcheck source=../../common.sh
+# shellcheck disable=SC1091
 source "$PKG_PATH/common.sh"
+# shellcheck source=./settings_functions.sh
+# shellcheck disable=SC1091
 source "$PKG_PATH/settings_functions.sh"
 CONFIG_FILE="${CONFIG_FILE:-$HOME/.local/share/4ndr0service/config.json}"
 create_config_if_missing

--- a/4ndr0tools/4ndr0service/view/cli.sh
+++ b/4ndr0tools/4ndr0service/view/cli.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: view/cli.sh
 # Description: CLI menu interface for 4ndr0service Suite.
 
@@ -10,7 +9,8 @@ main_cli() {
 	PS3="Select: "
 	options=("Go" "Ruby" "Cargo" "Node.js" "Meson" "Python" "Electron" "Venv" "Audit" "Manage" "Settings" "Exit")
 
-	select opt in "${options[@]}"; do
+        # shellcheck disable=SC2034
+        select opt in "${options[@]}"; do
 		case $REPLY in
 		1) optimize_go_service ;;
 		2) optimize_ruby_service ;;

--- a/4ndr0tools/4ndr0service/view/dialog.sh
+++ b/4ndr0tools/4ndr0service/view/dialog.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=all
 # File: view/dialog.sh
 # Description: Dialog-based menu interface for 4ndr0service Suite.
 


### PR DESCRIPTION
## Summary
- remove global shellcheck disable lines
- add targeted shellcheck directives
- fix variable assignments and unused color constants
- document changes in CHANGELOG and task_outcome
- restore executable permissions

## Testing
- `shellcheck $(cat /tmp/shfiles.txt)`
- `shfmt -d $(cat /tmp/shfiles.txt)`
- `bats 0-tests/bats` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717d4b05f0832e8cb3705480f6fb69